### PR TITLE
Quartus Error 10644 fix - Added labels to for-loop generates

### DIFF
--- a/simulation/icarus/Makefile
+++ b/simulation/icarus/Makefile
@@ -10,7 +10,7 @@ HW_INCLUDE :=	-I. -I$(RTL_DIR)/testbench/ -I$(RTL_DIR)/include/ -I$(SUBMODULES_D
 VLOG = 	iverilog -W all -g2005-sv -DVCD
 
 #hardware sources
-VSRC :=	$(RTL_DIR)/testbench/iob-cache_tb.v $(RTL_DIR)/src/*.v $(RTL_DIR)/wrapper/L2_ID_1sp.v $(SUBMODULES_DIR)/iob-mem/sp_ram_be/iob_sp_ram_be.v $(SUBMODULES_DIR)/iob-mem/fifo/afifo/afifo.v $(SUBMODULES_DIR)/iob-mem/reg_file/iob_reg_file.v $(SUBMODULES_DIR)/axi-mem/rtl/axi_ram.v $(SUBMODULES_DIR)/iob-interconnect/rtl/src/merge.v $(SUBMODULES_DIR)/iob-mem/sp_ram/iob_sp_mem.v 
+VSRC :=	$(RTL_DIR)/testbench/iob-cache_tb.v $(RTL_DIR)/src/*.v $(RTL_DIR)/wrapper/L2_ID_1sp.v $(SUBMODULES_DIR)/iob-mem/sp_ram_be/iob_sp_ram_be.v $(SUBMODULES_DIR)/iob-mem/fifo/afifo/afifo.v $(SUBMODULES_DIR)/iob-mem/reg_file/iob_reg_file.v $(SUBMODULES_DIR)/axi-mem/rtl/axi_ram.v  $(SUBMODULES_DIR)/iob-mem/sp_ram/iob_sp_mem.v 
 
 all:	$(VSRC)
 	$(VLOG) $(HW_INCLUDE)	-o iob_cache_tb $(VSRC)


### PR DESCRIPTION
- Fixed Quartus synthesis error 10644, which is fixable by merely adding labels/names to the for-loop generates.

source: https://stackoverflow.com/questions/33899691/instantiate-modules-in-generate-for-loop-in-verilog