### PR TITLE
Write-miss -> Line replacement issue fix

### DIFF
--- a/hardware/fpga/AES-KU040-DB-G/Makefile
+++ b/hardware/fpga/AES-KU040-DB-G/Makefile
@@ -12,7 +12,7 @@ synth: *.xdc $(VSRC)
 	-grep -B1 -A9 ^Slack vivado.log && echo
 
 GARBAGE:=.Xil/ *.map *. *~ synth_*.mmi synth_*.bit synth_system*.v *.vcd *_tb \
-table.txt tab_*/ *webtalk* *.jou *.log .log xelab.* xsim[._]* xvlog.* uart_loader *.ltx fsm_encoding.os
+table.txt tab_*/ *webtalk* *.jou *.log .log xelab.* xsim[._]* xvlog.* uart_loader *.ltx fsm_encoding.os *.txt
 
 fpga-clean:
 	rm -rf $(GARBAGE)

--- a/hardware/fpga/AES-KU040-DB-G/synth.tcl
+++ b/hardware/fpga/AES-KU040-DB-G/synth.tcl
@@ -23,5 +23,8 @@ read_xdc ./synth.xdc
 
 synth_design -include_dirs $HW_INCLUDE -part $PART -top $TOP
 
+#multiple tables showing the resources,but not for each module
 report_utilization
 
+#table with all the modules, simplified
+report_utilization -hierarchical

--- a/hardware/hardware.mk
+++ b/hardware/hardware.mk
@@ -14,5 +14,6 @@ VHDR+=$(wildcard $(CACHE_INC_DIR)/*.vh)
 CACHE_SRC_DIR:=$(CACHE_DIR)/hardware/src
 VSRC+=$(wildcard $(CACHE_HW_DIR)/src/*.v) \
 $(CACHE_MEM_DIR)/reg_file/iob_reg_file.v \
-$(CACHE_MEM_DIR)/fifo/afifo/afifo.v \
+$(CACHE_MEM_DIR)/fifo/sfifo/sfifo.v \
+$(CACHE_MEM_DIR)/2p_mem/iob_2p_mem.v \
 $(CACHE_MEM_DIR)/sp_ram/iob_sp_mem.v

--- a/hardware/src/back-end-native.v
+++ b/hardware/src/back-end-native.v
@@ -264,7 +264,7 @@ module read_channel_native
                        idle:
                          begin
                             
-                            if(read_miss) //main_process flag
+                            if(replace_valid)
                               state <= handshake;                                        
                             else
                               state <= idle;                      
@@ -281,7 +281,6 @@ module read_channel_native
                        end_handshake: //read-latency delay (last line word)
                          begin
                             state <= idle;
-                            word_counter <= 0;
                          end
                        
                        default:;

--- a/hardware/src/cache-memory.v
+++ b/hardware/src/cache-memory.v
@@ -106,7 +106,7 @@ module cache_memory
    assign wtbuf_empty = buffer_empty & write_ready & ~write_valid;
    
 
-   iob_async_fifo #(
+   /*iob_async_fifo #(
 		    .DATA_WIDTH    (FE_ADDR_W-FE_BYTE_W + FE_DATA_W + FE_NBYTES),
 		    .ADDRESS_WIDTH (WTBUF_DEPTH_W)
 		    ) 
@@ -124,7 +124,24 @@ module cache_memory
       .write_en(write_access & ready),
       .wclk    (clk)
       );
-
+*/
+iob_sync_fifo #(
+		    .DATA_WIDTH    (FE_ADDR_W-FE_BYTE_W + FE_DATA_W + FE_NBYTES),
+		    .ADDRESS_WIDTH (WTBUF_DEPTH_W)
+		    ) 
+   write_throught_buffer 
+     (
+      .rst     (reset),
+      .clk (clk),
+      .fifo_ocupancy (),       
+      .data_out(buffer_dout), 
+      .empty   (buffer_empty),
+      .read_en (write_ready),  
+      .data_in ({addr_reg,wdata_reg,wstrb_reg}), 
+      .full    (buffer_full),
+      .write_en(write_access & ready)
+      );
+   
    //back-end read channel
    assign replace_valid = (~hit & read_access_reg & replace_ready) & (buffer_empty & write_ready);
    assign replace_addr  = addr[FE_ADDR_W -1:BE_BYTE_W+LINE2MEM_W];

--- a/hardware/src/iob-cache.v
+++ b/hardware/src/iob-cache.v
@@ -10,9 +10,9 @@ module iob_cache
     //memory cache's parameters
     parameter FE_ADDR_W   = 32,       //Address width - width of the Master's entire access address (including the LSBs that are discarded, but discarding the Controller's)
     parameter FE_DATA_W   = 32,       //Data width - word size used for the cache
-    parameter N_WAYS   = 4,        //Number of Cache Ways (Needs to be Potency of 2: 1, 2, 4, 8, ..)
-    parameter LINE_OFF_W  = 6,     //Line-Offset Width - 2**NLINE_W total cache lines
-    parameter WORD_OFF_W = 3,      //Word-Offset Width - 2**OFFSET_W total FE_DATA_W words per line - WARNING about LINE2MEM_W (can cause word_counter [-1:0]
+    parameter N_WAYS   = 2,        //Number of Cache Ways (Needs to be Potency of 2: 1, 2, 4, 8, ..)
+    parameter LINE_OFF_W  = 4,    //Line-Offset Width - 2**NLINE_W total cache lines
+    parameter WORD_OFF_W = 2,      //Word-Offset Width - 2**OFFSET_W total FE_DATA_W words per line - WARNING about LINE2MEM_W (can cause word_counter [-1:0]
     parameter WTBUF_DEPTH_W = 4,   //Depth Width of Write-Through Buffer
     //Replacement policy (N_WAYS > 1)
     parameter REP_POLICY = `LRU, //LRU - Least Recently Used (0); BIT_PLRU (1) - bit-based pseudoLRU; TREE_PLRU (2) - tree-based pseudoLRU

--- a/hardware/testbench/pipeline-iob-cache_tb.v
+++ b/hardware/testbench/pipeline-iob-cache_tb.v
@@ -37,8 +37,8 @@ module iob_cache_tb;
         reset = 0;
         #10;
 
-        $display("\nInitializing Cache testing - printing errors only\n");
-        $display("Test 1 - Writing entire memory (Data width words)\n");
+        $display("\nInitializing Cache testing - check simulation results\n");
+        $display("Test 1 - Writing test\n");
         test <= 1;
         for (i = 0; i < 10; i = i + 1)
           begin
@@ -53,7 +53,7 @@ module iob_cache_tb;
              while (ready == 1'b0) #2;
         end // for (i = 0; i < 2**(`ADDR_W-$clog2(`DATA_W/8)); i = i + 1)
 
-        $display("Test 2 - Reading entire memory (Data width words)\n");
+        $display("Test 2 - Reading Test\n");
         test <= 2;
         pipe_en <= 1;
         addr <= 0;
@@ -88,9 +88,20 @@ module iob_cache_tb;
         while (ready == 1'b0) #2;
         #2;
         pipe_en <= 0;
-
         #20;
         
+        $display("Test 4 - Test Line Replacement with read the last written position\n");
+        test <= 4;
+        addr <= (2**`WORD_OFF_W)*5-1;
+        valid <= 1;
+        wstrb <= {`DATA_W/8{1'b1}};
+        wdata <= 3735928559;
+        #2;
+        wstrb <= 0;
+        #2;
+        valid <=0;
+        while (ready == 1'b0) #2;
+        #20;   
         $display("Cache testing completed\n");
         $finish;
      end


### PR DESCRIPTION
- Previous FIFO would take longer to deassert "empty" resulting in a read after a write-miss to start the line-replacement before the data was written to the back-memory.
- Changed to sync-fifo.
- small bugfixing and synth.tcl improvements