### PR TITLE
Fixing synthesis warnings; Changed back-end native transfers to allow the correct use of L2

### DIFF
--- a/hardware/src/back-end-native.v
+++ b/hardware/src/back-end-native.v
@@ -2,24 +2,24 @@
 `include "iob-cache.vh"
 
 module back_end_native
-    #(
-      //memory cache's parameters
-      parameter FE_ADDR_W   = 32,       //Address width - width of the Master's entire access address (including the LSBs that are discarded, but discarding the Controller's)
-      parameter FE_DATA_W   = 32,       //Data width - word size used for the cache
-      parameter WORD_OFF_W = 3,      //Word-Offset Width - 2**OFFSET_W total FE_DATA_W words per line - WARNING about LINE2MEM_W (can cause word_counter [-1:0]
-      parameter BE_ADDR_W = FE_ADDR_W, //Address width of the higher hierarchy memory
-      parameter BE_DATA_W = FE_DATA_W, //Data width of the memory
+  #(
+    //memory cache's parameters
+    parameter FE_ADDR_W   = 32,       //Address width - width of the Master's entire access address (including the LSBs that are discarded, but discarding the Controller's)
+    parameter FE_DATA_W   = 32,       //Data width - word size used for the cache
+    parameter WORD_OFF_W = 3,      //Word-Offset Width - 2**OFFSET_W total FE_DATA_W words per line - WARNING about LINE2MEM_W (can cause word_counter [-1:0]
+    parameter BE_ADDR_W = FE_ADDR_W, //Address width of the higher hierarchy memory
+    parameter BE_DATA_W = FE_DATA_W, //Data width of the memory
 
-      parameter FE_NBYTES  = FE_DATA_W/8,        //Number of Bytes per Word
-      parameter FE_BYTE_W  = $clog2(FE_NBYTES), //Byte Offset
-      /*---------------------------------------------------*/
-      //Higher hierarchy memory (slave) interface parameters 
+    parameter FE_NBYTES  = FE_DATA_W/8,        //Number of Bytes per Word
+    parameter FE_BYTE_W  = $clog2(FE_NBYTES), //Byte Offset
+    /*---------------------------------------------------*/
+    //Higher hierarchy memory (slave) interface parameters 
 
-      parameter BE_NBYTES = BE_DATA_W/8, //Number of bytes
-      parameter BE_BYTE_W = $clog2(BE_NBYTES), //Offset of Number of Bytes
-      //Cache-Memory base Offset
+    parameter BE_NBYTES = BE_DATA_W/8, //Number of bytes
+    parameter BE_BYTE_W = $clog2(BE_NBYTES), //Offset of Number of Bytes
+    //Cache-Memory base Offset
     parameter LINE2MEM_W = WORD_OFF_W-$clog2(BE_DATA_W/FE_DATA_W)
-   
+  
     ) 
    (
     input                                        clk,
@@ -44,7 +44,7 @@ module back_end_native
     output [BE_NBYTES-1:0]                       mem_wstrb,
     input [BE_DATA_W-1:0]                        mem_rdata,
     input                                        mem_ready
-  );
+    );
 
    wire [BE_ADDR_W-1:0]                          mem_addr_read,  mem_addr_write;
    wire                                          mem_valid_read, mem_valid_write;
@@ -118,20 +118,20 @@ module read_channel_native
     //Cache-Memory base Offset
     parameter LINE2MEM_W = WORD_OFF_W-$clog2(BE_DATA_W/FE_DATA_W) //burst offset based on the cache word's and memory word size
     )
-    (
-     input                                        clk,
-     input                                        reset,
-     input                                        replace_valid,
-     input [FE_ADDR_W -1: BE_BYTE_W + LINE2MEM_W] replace_addr,
-     output reg                                   replace_ready,
-     output  reg                                     read_valid,
-     output reg [LINE2MEM_W-1:0]                  read_addr,
-     output [BE_DATA_W-1:0]                       read_rdata,
-     //Native memory interface
-     output [BE_ADDR_W -1:0]                      mem_addr,
-     output reg                                   mem_valid,
-     input                                        mem_ready,
-     input [BE_DATA_W-1:0]                        mem_rdata
+   (
+    input                                        clk,
+    input                                        reset,
+    input                                        replace_valid,
+    input [FE_ADDR_W -1: BE_BYTE_W + LINE2MEM_W] replace_addr,
+    output reg                                   replace_ready,
+    output reg                                   read_valid,
+    output reg [LINE2MEM_W-1:0]                  read_addr,
+    output [BE_DATA_W-1:0]                       read_rdata,
+    //Native memory interface
+    output [BE_ADDR_W -1:0]                      mem_addr,
+    output reg                                   mem_valid,
+    input                                        mem_ready,
+    input [BE_DATA_W-1:0]                        mem_rdata
     );
 
    generate
@@ -143,7 +143,7 @@ module read_channel_native
            assign mem_addr  = {BE_ADDR_W{1'b0}} + {replace_addr[FE_ADDR_W -1: BE_BYTE_W + LINE2MEM_W], word_counter, {BE_BYTE_W{1'b0}}};
            
 
-          // assign read_valid = mem_ready;
+           // assign read_valid = mem_ready;
            assign read_rdata = mem_rdata;
 
            localparam
@@ -154,7 +154,7 @@ module read_channel_native
            always @ (posedge clk)
              read_addr <= word_counter;
            
-           reg [1:0]                                  state;
+           reg [1:0]            state;
 
            always @(posedge clk, posedge reset)
              begin
@@ -222,7 +222,7 @@ module read_channel_native
                        word_counter = word_counter + mem_ready;
                        read_valid = mem_ready;
                     end
-                                   
+                  
                   default:;
                   
                   
@@ -233,7 +233,7 @@ module read_channel_native
         begin
            assign mem_addr  = {BE_ADDR_W{1'b0}} + {replace_addr, {BE_BYTE_W{1'b0}}};
            
-          // assign read_valid = mem_valid; //doesn require line_load since when mem_valid is HIGH, so is line_load.
+           // assign read_valid = mem_valid; //doesn require line_load since when mem_valid is HIGH, so is line_load.
            assign read_rdata = mem_rdata;
 
            localparam
@@ -349,7 +349,7 @@ module write_channel_native
      init_process  = 3'd1,
      write_process = 3'd2;
    
-   reg [1:0]                                              state;
+   reg [1:0]                      state;
 
    generate
       if(BE_DATA_W == FE_DATA_W)

--- a/hardware/src/back-end-native.v
+++ b/hardware/src/back-end-native.v
@@ -204,34 +204,25 @@ module read_channel_native
            
            always @*
              begin 
-                //word_counter =0;
+                mem_valid     = 1'b0;
+                replace_ready = 1'b0;
+                word_counter  = 0;
+                read_valid    = 1'b0;
                 
                 case(state)
                   
                   idle:
                     begin
-                       mem_valid = 1'b0;
                        replace_ready = 1'b1;
-                       word_counter = 0;
-                       read_valid = 1'b0;
                     end
 
                   handshake:
                     begin
-                       mem_valid = 1'b1;
-                       replace_ready = 1'b0;
+                       mem_valid = ~mem_ready | ~(&read_addr);
                        word_counter = word_counter + mem_ready;
                        read_valid = mem_ready;
                     end
-                  
-                  end_handshake:
-                    begin
-                       word_counter = 0;
-                       replace_ready = 1'b0; //delay for read-latency
-                       mem_valid = 1'b0;
-                       read_valid = 1'b0;
-                    end
-                  
+                                   
                   default:;
                   
                   
@@ -292,32 +283,21 @@ module read_channel_native
            
            always @*
              begin 
-                
+                mem_valid     = 1'b0;
+                replace_ready = 1'b0;
+                read_valid    = 1'b0;
                 
                 case(state)
                   
                   idle:
                     begin
-                       mem_valid = 1'b0;
                        replace_ready = 1'b1;
-                       read_valid = 1'b0;
-                       
                     end
 
                   handshake:
                     begin
-                       mem_valid = 1'b1;
-                       replace_ready = 1'b0;
+                       mem_valid = ~mem_ready;
                        read_valid = mem_ready;
-                       
-                    end
-                  
-                  end_handshake:
-                    begin
-                       replace_ready = 1'b0; //delay for read-latency
-                       mem_valid = 1'b0;
-                       read_valid = 1'b0;
-                       
                     end
                   
                   default:;
@@ -449,7 +429,7 @@ module write_channel_native
           idle:
             ready = 1'b1;
           write_process:
-            mem_valid = 1'b1;
+            mem_valid = ~mem_ready;
           default:;
         endcase // case (state)
      end

--- a/hardware/src/cache-memory.v
+++ b/hardware/src/cache-memory.v
@@ -29,7 +29,7 @@ module cache_memory
      input                                      reset,
      //front-end
      input                                      valid,
-     input [FE_ADDR_W-1:FE_BYTE_W]              addr,
+     input [FE_ADDR_W-1:FE_BYTE_W + LINE2MEM_W] addr,
      input [FE_DATA_W-1:0]                      wdata,
      input [FE_NBYTES-1:0]                      wstrb,
      output [FE_DATA_W-1:0]                     rdata,
@@ -39,7 +39,6 @@ module cache_memory
      input [FE_ADDR_W-1:FE_BYTE_W]              addr_reg,
      input [FE_DATA_W-1:0]                      wdata_reg,
      input [FE_NBYTES-1:0]                      wstrb_reg,
-     output [FE_DATA_W-1:0]                     rdata_reg,
      //back-end write-channel
      output                                     write_valid,
      output [FE_ADDR_W-1:FE_BYTE_W]             write_addr,
@@ -157,6 +156,11 @@ iob_sync_fifo #(
    assign ready = (hit & (read_access_reg) & (replace_ready) & RAW_prev) | (~buffer_full & (write_access_reg));
    // read section needs to be the registered, so it doesn't change the moment ready asserts and updates the input. Write doesn't update on the same cycle as ready asserts, and in the next clock cycle, will have the next input.
 
+   //cache-control hit-miss counters enables
+   assign write_hit =  ready & ( hit & write_access_reg);
+   assign write_miss = ready & (~hit & write_access_reg);
+   assign read_hit = ready &  ( hit & read_access_reg);
+   assign read_miss = ready & (~hit & read_access_reg);
    
    genvar                                                   i,j,k;
    generate

--- a/hardware/src/front-end.v
+++ b/hardware/src/front-end.v
@@ -40,7 +40,6 @@ module front_end
     output  [FE_ADDR_W-1:FE_BYTE_W]          data_addr_reg,
     output  [FE_DATA_W-1:0]                  data_wdata_reg,
     output  [FE_NBYTES-1:0]                  data_wstrb_reg,
-    output  [FE_DATA_W-1:0]                  data_rdata_reg,
     //cache-control
     output                                      ctrl_valid,
     output [`CTRL_ADDR_W-1:0]                   ctrl_addr, 

--- a/hardware/src/front-end.v
+++ b/hardware/src/front-end.v
@@ -36,23 +36,23 @@ module front_end
     input [FE_DATA_W-1:0]                       data_rdata,
     input                                       data_ready,
     //stored input signals
-    output                                   data_valid_reg,
-    output  [FE_ADDR_W-1:FE_BYTE_W]          data_addr_reg,
-    output  [FE_DATA_W-1:0]                  data_wdata_reg,
-    output  [FE_NBYTES-1:0]                  data_wstrb_reg,
+    output                                      data_valid_reg,
+    output [FE_ADDR_W-1:FE_BYTE_W]              data_addr_reg,
+    output [FE_DATA_W-1:0]                      data_wdata_reg,
+    output [FE_NBYTES-1:0]                      data_wstrb_reg,
     //cache-control
     output                                      ctrl_valid,
     output [`CTRL_ADDR_W-1:0]                   ctrl_addr, 
-    input [FE_DATA_W-1:0]                       ctrl_rdata,
+    input [CTRL_CACHE*(FE_DATA_W-1):0]          ctrl_rdata,
     input                                       ctrl_ready
     );
 
-   wire                                          valid_int;
+   wire                                         valid_int;
    
-   reg                                           valid_reg;
-   reg [FE_ADDR_W-1:FE_BYTE_W]                   addr_reg;
-   reg [FE_DATA_W-1:0]                           wdata_reg;
-   reg [FE_NBYTES-1:0]                           wstrb_reg;
+   reg                                          valid_reg;
+   reg [FE_ADDR_W-1:FE_BYTE_W]                  addr_reg;
+   reg [FE_DATA_W-1:0]                          wdata_reg;
+   reg [FE_NBYTES-1:0]                          wstrb_reg;
 
    assign data_valid_reg = valid_reg;
    assign data_addr_reg = addr_reg;
@@ -60,7 +60,7 @@ module front_end
    assign data_wstrb_reg = wstrb_reg;
 
 
-   wire                                          reset_valid_reg = ~valid_int & data_ready;
+   wire                                         reset_valid_reg = ~valid_int & data_ready;
    
    
    //////////////////////////////////////////////////////////////////////////////////
@@ -87,13 +87,13 @@ module front_end
            assign ready = data_ready; 
            
            assign rdata = data_rdata;
-  
+           
            assign valid_int = valid;
            
            assign ctrl_valid = 1'bx;
            
            assign ctrl_addr = `CTRL_ADDR_W'dx;
-        
+           
         end // else: !if(CTRL_CACHE)
    endgenerate
 

--- a/hardware/src/iob-cache.v
+++ b/hardware/src/iob-cache.v
@@ -26,7 +26,7 @@ module iob_cache
     parameter BE_DATA_W = FE_DATA_W, //Data width of the memory 
     parameter BE_NBYTES = BE_DATA_W/8, //Number of bytes
     parameter BE_BYTE_W = $clog2(BE_NBYTES), //Offset of Number of Bytes
-                                                                                        //Cache-Memory base Offset
+    //Cache-Memory base Offset
     parameter LINE2MEM_W = WORD_OFF_W-$clog2(BE_DATA_W/FE_DATA_W),//Logarithm Ratio between the size of the cache-line and the BE's data width 
     /*---------------------------------------------------*/
   
@@ -35,61 +35,61 @@ module iob_cache
     parameter CTRL_CNT = 0  //Counters for Cache Hits and Misses - Disabling this and previous, the Controller only store the buffer states and allows cache invalidation
     ) 
    (
-    input                                        clk,
-    input                                        reset,
+    input                                       clk,
+    input                                       reset,
     //Master i/f
-    input                                        valid,
+    input                                       valid,
 `ifdef WORD_ADDR   
     input [CTRL_CACHE + FE_ADDR_W -1:FE_BYTE_W] addr, //MSB is used for Controller selection
 `else
-    input [CTRL_CACHE + FE_ADDR_W -1:0]          addr, //MSB is used for Controller selection
+    input [CTRL_CACHE + FE_ADDR_W -1:0]         addr, //MSB is used for Controller selection
 `endif
-    input [FE_DATA_W-1:0]                        wdata,
-    input [FE_NBYTES-1:0]                        wstrb,
-    output [FE_DATA_W-1:0]                       rdata,
-    output                                       ready,
+    input [FE_DATA_W-1:0]                       wdata,
+    input [FE_NBYTES-1:0]                       wstrb,
+    output [FE_DATA_W-1:0]                      rdata,
+    output                                      ready,
     //Slave i/f - Native
-    output                                       mem_valid,
-    output [BE_ADDR_W-1:0]                       mem_addr,
-    output [BE_DATA_W-1:0]                       mem_wdata,
-    output [BE_NBYTES-1:0]                       mem_wstrb,
-    input [BE_DATA_W-1:0]                        mem_rdata,
-    input                                        mem_ready
+    output                                      mem_valid,
+    output [BE_ADDR_W-1:0]                      mem_addr,
+    output [BE_DATA_W-1:0]                      mem_wdata,
+    output [BE_NBYTES-1:0]                      mem_wstrb,
+    input [BE_DATA_W-1:0]                       mem_rdata,
+    input                                       mem_ready
     );
 
    
    //internal signals (front-end inputs)
-   wire                                          data_valid, data_ready;
-   wire [FE_ADDR_W -1:FE_BYTE_W]                 data_addr; 
-   wire [FE_DATA_W-1 : 0]                        data_wdata, data_rdata;
-   wire [FE_NBYTES-1: 0]                         data_wstrb;
+   wire                                         data_valid, data_ready;
+   wire [FE_ADDR_W -1:FE_BYTE_W]                data_addr; 
+   wire [FE_DATA_W-1 : 0]                       data_wdata, data_rdata;
+   wire [FE_NBYTES-1: 0]                        data_wstrb;
    
    //stored signals
-   wire [FE_ADDR_W -1:FE_BYTE_W]                 data_addr_reg; 
-   wire [FE_DATA_W-1 : 0]                        data_wdata_reg;
-   wire [FE_NBYTES-1: 0]                         data_wstrb_reg;
-   wire                                          data_valid_reg;
+   wire [FE_ADDR_W -1:FE_BYTE_W]                data_addr_reg; 
+   wire [FE_DATA_W-1 : 0]                       data_wdata_reg;
+   wire [FE_NBYTES-1: 0]                        data_wstrb_reg;
+   wire                                         data_valid_reg;
 
    //back-end write-channel
-   wire                                          write_valid, write_ready;
-   wire [FE_ADDR_W-1: FE_BYTE_W]                 write_addr;
-   wire [FE_DATA_W-1:0]                          write_wdata;
-   wire [FE_NBYTES-1:0]                          write_wstrb;
+   wire                                         write_valid, write_ready;
+   wire [FE_ADDR_W-1: FE_BYTE_W]                write_addr;
+   wire [FE_DATA_W-1:0]                         write_wdata;
+   wire [FE_NBYTES-1:0]                         write_wstrb;
    
    //back-end read-channel
-   wire                                          replace_valid, replace_ready;
+   wire                                         replace_valid, replace_ready;
    wire [FE_ADDR_W -1:BE_BYTE_W+LINE2MEM_W]     replace_addr; 
-   wire                                          read_valid;
-   wire [LINE2MEM_W-1:0]              read_addr;
-   wire [BE_DATA_W-1:0]                          read_rdata;
-  
+   wire                                         read_valid;
+   wire [LINE2MEM_W-1:0]                        read_addr;
+   wire [BE_DATA_W-1:0]                         read_rdata;
+   
    //cache-control
-   wire                                          ctrl_valid, ctrl_ready;   
-   wire [`CTRL_ADDR_W-1:0]                       ctrl_addr;
-   wire                                          wtbuf_full, wtbuf_empty;
-   wire                                          write_hit, write_miss, read_hit, read_miss;
-   wire [FE_DATA_W-1:0]                          ctrl_rdata;
-   wire                                          invalidate;
+   wire                                         ctrl_valid, ctrl_ready;   
+   wire [`CTRL_ADDR_W-1:0]                      ctrl_addr;
+   wire                                         wtbuf_full, wtbuf_empty;
+   wire                                         write_hit, write_miss, read_hit, read_miss;
+   wire [CTRL_CACHE*(FE_DATA_W-1):0]            ctrl_rdata;
+   wire                                         invalidate;
 
    front_end
      #(
@@ -222,7 +222,7 @@ module iob_cache
    
    generate
       if (CTRL_CACHE)
-        
+         
         cache_control
           #(
             .FE_DATA_W  (FE_DATA_W),
@@ -249,7 +249,7 @@ module iob_cache
          );
       else
         begin
-           assign ctrl_rdata = {FE_DATA_W{1'bx}};
+           assign ctrl_rdata = 1'bx;
            assign ctrl_ready = 1'bx;
            assign invalidate = 1'b0;
         end // else: !if(CTRL_CACHE)
@@ -257,9 +257,3 @@ module iob_cache
    endgenerate
 
 endmodule // iob_cache   
-
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/hardware/src/iob-cache.v
+++ b/hardware/src/iob-cache.v
@@ -147,7 +147,7 @@ module iob_cache
       //front-end
       //internal data signals
       .valid (data_valid),
-      .addr  (data_addr),
+      .addr  (data_addr[FE_ADDR_W-1:FE_BYTE_W + LINE2MEM_W]),
       .wdata (data_wdata),
       .wstrb (data_wstrb),
       .rdata (data_rdata),
@@ -222,7 +222,7 @@ module iob_cache
    
    generate
       if (CTRL_CACHE)
-         
+        
         cache_control
           #(
             .FE_DATA_W  (FE_DATA_W),
@@ -247,6 +247,12 @@ module iob_cache
          .ready (ctrl_ready),
          .invalidate (invalidate)
          );
+      else
+        begin
+           assign ctrl_rdata = {FE_DATA_W{1'bx}};
+           assign ctrl_ready = 1'bx;
+           assign invalidate = 1'b0;
+        end // else: !if(CTRL_CACHE)
       
    endgenerate
 


### PR DESCRIPTION
There are 2 warnings that currently are unfixable:
Front-end - Unconnected ports:
- ctrl_rdata and ctrl_ready. This 2 signals from cache-control are inputs in the front-end, but aren't usuable in the front-end if it isn't implemented (CTRL_CACHE(0)). 

Changed back-end Native interface so it will work correctly with the L2 cache, avoiding repeated tasks (valid deasserts when receiving the (last) ready);
Fixed latching issues.