### PR TITLE
RAW important (temporary) fix

### DIFF
--- a/hardware/src/cache-memory.v
+++ b/hardware/src/cache-memory.v
@@ -142,7 +142,10 @@ module cache_memory
         way_hit_prev <= way_hit;
      end
 
-   assign raw = write_hit_prev & (way_hit == way_hit) & (index_prev == index_reg) & (offset_prev == offset);
+   //assign raw = write_hit_prev & (way_hit == way_hit) & (index_prev == index_reg) & (offset_prev == offset);//issue - currently a RAW in different indexes in the way-hit causes the read to read from the write addr.
+   assign raw = write_hit_prev;
+
+
    
    assign hit = |way_hit & replace_ready & (~raw);//way_hit is also used during line replacement (to update that respective way). Hit is when there is a hit in a way and there isn't occuring a line-replacement (read-miss). 
 


### PR DESCRIPTION
Fixed RAW problem (less optimal though): L2 dhrystone (8KB) 100 runs CPI 1,284 to 1,330 (but without artifacts in printfs).
Working in multiple different configurations without any issue.
L1-ID are artifactless, though sometimes only prints part of the number of the number of cycles (didn't seem to be a iob-cache issue). Works will multiple configurations.
Works on both -0s and -03. From low number of Dhrystone runs to high (up to 1000)