### PR TITLE
Fixes to cache control by software

### DIFF
--- a/software/iob-cache.c
+++ b/software/iob-cache.c
@@ -4,9 +4,9 @@
 
 static int cache_base;
 
-void cache_init(int cache_addr)
+void cache_init(int ext_mem, int cache_addr)
 {
-  cache_base = 1 << (cache_addr);
+  cache_base = ext_mem + (1 << (cache_addr));
 }
 
 int cache_invalidate()   {return (CACHEFUNC(cache_base,INVALIDATE));}

--- a/software/iob-cache.h
+++ b/software/iob-cache.h
@@ -6,21 +6,21 @@ static int cache_base;
 #define CACHEFUNC(cache_base, func) (*((volatile int*) (cache_base + (func * sizeof(int)))))
 
 //Function's memory map
-#define INVALIDATE      0
-#define BUFFER_EMPTY    1
-#define BUFFER_FULL     2
-#define HIT             3
-#define MISS            4
-#define READ_HIT        5
-#define READ_MISS       6
-#define WRITE_HIT       7
-#define WRITE_MISS      8
-#define COUNTER_RESET   9
-#define INSTR_HIT       10 //for CTRL_CNT_ID only
-#define INSTR_MISS      11 //for CTRL_CNT_ID only
+#define INVALIDATE      1
+#define BUFFER_EMPTY    2
+#define BUFFER_FULL     3
+#define HIT             4
+#define MISS            5
+#define READ_HIT        6
+#define READ_MISS       7
+#define WRITE_HIT       8
+#define WRITE_MISS      9
+#define COUNTER_RESET   10
+#define INSTR_HIT       11 //for CTRL_CNT_ID only
+#define INSTR_MISS      12 //for CTRL_CNT_ID only
 
 // Cache Controllers's functions
-void cache_init(int cache_addr); // initialized the cache_base static integer
+void cache_init(int ext_mem, int cache_addr); // initialized the cache_base static integer
 int cache_invalidate(); 
 int cache_buffer_empty();    
 int cache_buffer_full();


### PR DESCRIPTION
- control instructions memory mapping is now the same as the hardware mapping
- cache_base initialization requires base_address so that iob-soc addresses the external memory to begin with