### PR TITLE
Cache-memory optimization (RAW) and  bug-fixing & Cache-Control implementation

### DIFF
--- a/hardware/include/iob-cache.vh
+++ b/hardware/include/iob-cache.vh
@@ -1,6 +1,6 @@
 
 //Address-port
-//`define WORD_ADDR // Word-addressable, (BE) addr becomes word-addressable (doesn't receive the byte-offset).
+`define WORD_ADDR // Word-addressable, (BE) addr becomes word-addressable (doesn't receive the byte-offset).
 
 
 //Replacement Policy

--- a/hardware/simulation/iob-cache-gtkwave.gtkw
+++ b/hardware/simulation/iob-cache-gtkwave.gtkw
@@ -1,31 +1,20 @@
 [*]
 [*] GTKWave Analyzer v3.3.61 (w)1999-2014 BSI
-[*] Wed Sep 16 14:23:34 2020
+[*] Mon Sep 28 17:21:31 2020
 [*]
-[dumpfile] "/home/jroque/sandbox/iob-soc/submodules/iob-cache/hardware/simulation/icarus/iob_cache.vcd"
-[dumpfile_mtime] "Wed Sep 16 14:23:25 2020"
-[dumpfile_size] 90070
-[savefile] "/home/jroque/sandbox/iob-soc/submodules/iob-cache/hardware/simulation/iob-cache-gtkwave.gtkw"
-[timestart] 441410
+[dumpfile] "/home/jroque/sandbox/iob-soc-ssrv-test/submodules/iob-cache/hardware/simulation/icarus/iob_cache.vcd"
+[dumpfile_mtime] "Mon Sep 28 16:34:14 2020"
+[dumpfile_size] 114504
+[savefile] "/home/jroque/sandbox/iob-soc-ssrv-test/submodules/iob-cache/hardware/simulation/iob-cache-gtkwave.gtkw"
+[timestart] 268400
 [size] 1855 951
 [pos] -733 -1
-*-13.931433 472500 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
+*-15.931433 488000 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
 [treeopen] iob_cache_tb.
 [treeopen] iob_cache_tb.cache.
 [treeopen] iob_cache_tb.cache.back_end.
 [treeopen] iob_cache_tb.cache.back_end.read_fsm.
 [treeopen] iob_cache_tb.cache.back_end.write_fsm.
-[treeopen] iob_cache_tb.cache.cache_memory.
-[treeopen] iob_cache_tb.cache.cache_memory.genblk2.
-[treeopen] iob_cache_tb.cache.cache_memory.genblk2.line_way[0].
-[treeopen] iob_cache_tb.cache.cache_memory.genblk2.line_way[0].line_word_number[0].
-[treeopen] iob_cache_tb.cache.cache_memory.genblk2.line_way[0].line_word_number[0].line_word_width[0].
-[treeopen] iob_cache_tb.cache.cache_memory.genblk2.line_way[0].line_word_number[0].line_word_width[0].cache_memory.
-[treeopen] iob_cache_tb.cache.cache_memory.genblk2.line_way[0].line_word_number[0].line_word_width[1].
-[treeopen] iob_cache_tb.cache.cache_memory.genblk2.line_way[0].line_word_number[1].
-[treeopen] iob_cache_tb.cache.cache_memory.genblk2.line_way[0].line_word_number[1].line_word_width[0].
-[treeopen] iob_cache_tb.cache.cache_memory.genblk2.line_way[0].line_word_number[1].line_word_width[1].
-[treeopen] iob_cache_tb.cache.cache_memory.genblk2.line_way[1].
 [treeopen] iob_cache_tb.cache.cache_memory.write_throught_buffer.
 [sst_width] 234
 [signals_width] 662
@@ -42,8 +31,9 @@ iob_cache_tb.test[31:0]
 -Front-end
 @28
 iob_cache_tb.cache.front_end.valid
-@22
+@23
 iob_cache_tb.cache.addr[11:2]
+@22
 iob_cache_tb.wdata[31:0]
 iob_cache_tb.wstrb[3:0]
 iob_cache_tb.rdata[31:0]
@@ -53,12 +43,9 @@ iob_cache_tb.ready
 -
 -cache-memory
 @28
-iob_cache_tb.cache.cache_memory.genblk2.line_way[0].line_word_number[0].line_word_width[1].cache_memory.clk
 iob_cache_tb.cache.cache_memory.valid
 iob_cache_tb.cache.cache_memory.valid_reg
 @22
-[color] 2
-iob_cache_tb.cache.cache_memory.addr[11:3]
 [color] 2
 iob_cache_tb.cache.cache_memory.addr_reg[11:2]
 @28
@@ -73,67 +60,31 @@ iob_cache_tb.cache.cache_memory.wdata_reg[31:0]
 iob_cache_tb.cache.cache_memory.wstrb_reg[3:0]
 [color] 2
 iob_cache_tb.cache.cache_memory.line_wstrb[15:0]
-@28
 [color] 2
-iob_cache_tb.cache.cache_memory.way_hit[1:0]
-@22
 iob_cache_tb.cache.cache_memory.tag[6:0]
 @28
-iob_cache_tb.cache.cache_memory.v[1:0]
 iob_cache_tb.cache.cache_memory.offset[1:0]
-@22
-iob_cache_tb.cache.cache_memory.line_rdata[255:0]
-@28
 iob_cache_tb.cache.cache_memory.replace_ready
 iob_cache_tb.cache.cache_memory.hit
 iob_cache_tb.cache.cache_memory.read_access_reg
+>-90
 iob_cache_tb.cache.cache_memory.write_access_reg
+>0
 [color] 1
 iob_cache_tb.cache.cache_memory.raw
-@29
+>-220
 [color] 5
 iob_cache_tb.cache.cache_memory.index_prev
-@28
+>0
 [color] 5
 iob_cache_tb.cache.cache_memory.index_reg
 [color] 3
 iob_cache_tb.cache.cache_memory.offset[1:0]
 [color] 3
 iob_cache_tb.cache.cache_memory.offset_prev[1:0]
-[color] 3
-iob_cache_tb.cache.cache_memory.offset_same
-[color] 2
-iob_cache_tb.cache.cache_memory.way_hit[1:0]
-[color] 2
-iob_cache_tb.cache.cache_memory.way_hit_prev[1:0]
 @200
 -
 -Wa 0 - data memories
-@28
-iob_cache_tb.cache.cache_memory.genblk2.line_way[0].line_word_number[0].line_word_width[0].cache_memory.en
-iob_cache_tb.cache.cache_memory.genblk2.line_way[0].line_word_number[0].line_word_width[0].cache_memory.addr
-@22
-[color] 2
-iob_cache_tb.cache.cache_memory.genblk2.line_way[0].line_word_number[0].line_word_width[0].cache_memory.data_in[31:0]
-[color] 2
-iob_cache_tb.cache.cache_memory.genblk2.line_way[0].line_word_number[0].line_word_width[0].cache_memory.we[3:0]
-iob_cache_tb.cache.cache_memory.genblk2.line_way[0].line_word_number[0].line_word_width[0].cache_memory.data_out[31:0]
-[color] 2
-iob_cache_tb.cache.cache_memory.genblk2.line_way[0].line_word_number[0].line_word_width[1].cache_memory.data_in[31:0]
-[color] 2
-iob_cache_tb.cache.cache_memory.genblk2.line_way[0].line_word_number[0].line_word_width[1].cache_memory.we[3:0]
-iob_cache_tb.cache.cache_memory.genblk2.line_way[0].line_word_number[0].line_word_width[1].cache_memory.data_out[31:0]
-[color] 2
-iob_cache_tb.cache.cache_memory.genblk2.line_way[0].line_word_number[1].line_word_width[0].cache_memory.data_in[31:0]
-[color] 2
-iob_cache_tb.cache.cache_memory.genblk2.line_way[0].line_word_number[1].line_word_width[0].cache_memory.we[3:0]
-iob_cache_tb.cache.cache_memory.genblk2.line_way[0].line_word_number[1].line_word_width[0].cache_memory.data_out[31:0]
-[color] 2
-iob_cache_tb.cache.cache_memory.genblk2.line_way[0].line_word_number[1].line_word_width[1].cache_memory.data_in[31:0]
-[color] 2
-iob_cache_tb.cache.cache_memory.genblk2.line_way[0].line_word_number[1].line_word_width[1].cache_memory.we[3:0]
-iob_cache_tb.cache.cache_memory.genblk2.line_way[0].line_word_number[1].line_word_width[1].cache_memory.data_out[31:0]
-@200
 -
 -Back-end NATIVE
 -
@@ -178,8 +129,6 @@ iob_cache_tb.cache.cache_memory.hit
 -
 @28
 iob_cache_tb.cache.back_end.read_fsm.genblk1.state[1:0]
-@22
-iob_cache_tb.cache.cache_memory.line_rdata[255:0]
 @200
 -
 -

--- a/hardware/simulation/iob-cache-gtkwave.gtkw
+++ b/hardware/simulation/iob-cache-gtkwave.gtkw
@@ -1,21 +1,23 @@
 [*]
 [*] GTKWave Analyzer v3.3.61 (w)1999-2014 BSI
-[*] Mon Sep 28 17:21:31 2020
+[*] Mon Sep 28 18:52:54 2020
 [*]
 [dumpfile] "/home/jroque/sandbox/iob-soc-ssrv-test/submodules/iob-cache/hardware/simulation/icarus/iob_cache.vcd"
-[dumpfile_mtime] "Mon Sep 28 16:34:14 2020"
-[dumpfile_size] 114504
+[dumpfile_mtime] "Mon Sep 28 18:51:00 2020"
+[dumpfile_size] 118022
 [savefile] "/home/jroque/sandbox/iob-soc-ssrv-test/submodules/iob-cache/hardware/simulation/iob-cache-gtkwave.gtkw"
-[timestart] 268400
+[timestart] 0
 [size] 1855 951
-[pos] -733 -1
-*-15.931433 488000 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
+[pos] -856 -1
+*-17.931433 224000 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
 [treeopen] iob_cache_tb.
 [treeopen] iob_cache_tb.cache.
 [treeopen] iob_cache_tb.cache.back_end.
 [treeopen] iob_cache_tb.cache.back_end.read_fsm.
 [treeopen] iob_cache_tb.cache.back_end.write_fsm.
 [treeopen] iob_cache_tb.cache.cache_memory.write_throught_buffer.
+[treeopen] iob_cache_tb.cache.genblk1.
+[treeopen] iob_cache_tb.cache.genblk1.cache_control.
 [sst_width] 234
 [signals_width] 662
 [sst_expanded] 1
@@ -31,9 +33,8 @@ iob_cache_tb.test[31:0]
 -Front-end
 @28
 iob_cache_tb.cache.front_end.valid
-@23
-iob_cache_tb.cache.addr[11:2]
 @22
+iob_cache_tb.cache.addr[12:2]
 iob_cache_tb.wdata[31:0]
 iob_cache_tb.wstrb[3:0]
 iob_cache_tb.rdata[31:0]
@@ -58,12 +59,8 @@ iob_cache_tb.cache.cache_memory.index_reg
 iob_cache_tb.cache.cache_memory.wdata_reg[31:0]
 [color] 7
 iob_cache_tb.cache.cache_memory.wstrb_reg[3:0]
-[color] 2
-iob_cache_tb.cache.cache_memory.line_wstrb[15:0]
-[color] 2
-iob_cache_tb.cache.cache_memory.tag[6:0]
 @28
-iob_cache_tb.cache.cache_memory.offset[1:0]
+[color] 2
 iob_cache_tb.cache.cache_memory.replace_ready
 iob_cache_tb.cache.cache_memory.hit
 iob_cache_tb.cache.cache_memory.read_access_reg
@@ -78,16 +75,25 @@ iob_cache_tb.cache.cache_memory.index_prev
 >0
 [color] 5
 iob_cache_tb.cache.cache_memory.index_reg
-[color] 3
-iob_cache_tb.cache.cache_memory.offset[1:0]
-[color] 3
-iob_cache_tb.cache.cache_memory.offset_prev[1:0]
 @200
 -
--Wa 0 - data memories
--
+-Cache-Control
+@28
+iob_cache_tb.cache.genblk1.cache_control.read_hit
+iob_cache_tb.cache.genblk1.cache_control.write_hit
+@29
+iob_cache_tb.cache.genblk1.cache_control.read_miss
+@28
+iob_cache_tb.cache.genblk1.cache_control.write_miss
+@22
+iob_cache_tb.cache.genblk1.cache_control.genblk1.hit_cnt[31:0]
+iob_cache_tb.cache.genblk1.cache_control.genblk1.miss_cnt[31:0]
+iob_cache_tb.cache.genblk1.cache_control.genblk1.write_hit_cnt[31:0]
+iob_cache_tb.cache.genblk1.cache_control.genblk1.read_hit_cnt[31:0]
+iob_cache_tb.cache.genblk1.cache_control.genblk1.read_miss_cnt[31:0]
+iob_cache_tb.cache.genblk1.cache_control.genblk1.write_miss_cnt[31:0]
+@200
 -Back-end NATIVE
--
 @28
 iob_cache_tb.clk
 @200
@@ -109,9 +115,6 @@ iob_cache_tb.cache.back_end.write_ready
 @28
 iob_cache_tb.cache.back_end.read_fsm.clk
 iob_cache_tb.cache.back_end.read_fsm.replace_valid
-@22
-iob_cache_tb.cache.back_end.read_fsm.replace_addr[11:4]
-@28
 iob_cache_tb.cache.back_end.read_fsm.replace_ready
 [color] 1
 iob_cache_tb.cache.back_end.read_fsm.read_valid
@@ -119,17 +122,10 @@ iob_cache_tb.cache.cache_memory.read_access_reg
 @22
 iob_cache_tb.cache.back_end.read_fsm.read_rdata[63:0]
 @28
-[color] 2
-iob_cache_tb.cache.back_end.read_fsm.read_addr
-[color] 2
-iob_cache_tb.cache.back_end.read_fsm.genblk1.state[1:0]
 [color] 1
 iob_cache_tb.cache.cache_memory.hit
 @200
 -
-@28
-iob_cache_tb.cache.back_end.read_fsm.genblk1.state[1:0]
-@200
 -
 -
 -

--- a/hardware/src/cache-control.v
+++ b/hardware/src/cache-control.v
@@ -1,0 +1,133 @@
+`timescale 1ns / 1ps
+`include "iob-cache.vh"
+/*------------------*/
+/* Cache Control */
+/*------------------*/
+//Module responsible for performance measuring, information about the current cache state, and other cache functions
+
+module cache_control #(
+                          parameter FE_DATA_W = 32,
+                          parameter CTRL_CNT = 1
+                          )
+   (
+    input                      clk,
+    input                      reset, 
+    input                      valid,
+    input [`CTRL_ADDR_W-1:0]   addr,
+    input                      wtbuf_full,
+    input                      wtbuf_empty,
+    input                      write_hit,
+    input                      write_miss,
+    input                      read_hit,
+    input                      read_miss,
+    output reg [FE_DATA_W-1:0] rdata,
+    output reg                 ready,
+    output reg                 invalidate
+    );
+
+   generate
+      if(CTRL_CNT)
+        begin
+           
+           reg [FE_DATA_W-1:0]             read_hit_cnt, read_miss_cnt, write_hit_cnt, write_miss_cnt;
+           wire [FE_DATA_W-1:0]            hit_cnt, miss_cnt;
+           reg                             counter_reset;
+
+           assign hit_cnt  = read_hit_cnt  + write_hit_cnt;
+           assign miss_cnt = read_miss_cnt + write_miss_cnt;
+           
+           always @ (posedge clk, posedge reset)
+             begin 		
+	        if (reset) 
+	          begin
+                     read_hit_cnt  <= {FE_DATA_W{1'b0}};
+	             read_miss_cnt <= {FE_DATA_W{1'b0}};
+	             write_hit_cnt  <= {FE_DATA_W{1'b0}};
+	             write_miss_cnt <= {FE_DATA_W{1'b0}};
+                  end
+                else
+                  begin
+                     if (counter_reset) 
+	               begin
+                          read_hit_cnt  <= {FE_DATA_W{1'b0}};
+	                  read_miss_cnt <= {FE_DATA_W{1'b0}};
+	                  write_hit_cnt  <= {FE_DATA_W{1'b0}};
+	                  write_miss_cnt <= {FE_DATA_W{1'b0}};
+                       end
+                     else
+	               if (read_hit)
+	                 begin
+		            read_hit_cnt <= read_hit_cnt + 1; 
+	                 end
+	               else if (write_hit)
+	                 begin
+		            write_hit_cnt <= write_hit_cnt + 1;
+	                 end
+	               else if (read_miss)
+	                 begin
+		            read_miss_cnt <= read_miss_cnt + 1;
+                            read_hit_cnt <= read_hit_cnt - 1;
+                         end
+	               else if (write_miss)
+	                 begin
+		            write_miss_cnt <= write_miss_cnt + 1;
+	                 end
+	               else
+	                 begin
+		            read_hit_cnt <= read_hit_cnt;
+		            read_miss_cnt <= read_miss_cnt;
+		            write_hit_cnt <= write_hit_cnt;
+		            write_miss_cnt <= write_miss_cnt;
+	                 end
+	          end // else: !if(ctrl_arst)   
+             end // always @ (posedge clk, posedge ctrl_arst)
+           
+           always @ (posedge clk)
+             begin
+	        rdata <= {FE_DATA_W{1'b0}};
+	        invalidate <= 1'b0;
+	        counter_reset <= 1'b0;
+	        ready <= valid; // Sends acknowlege the next clock cycle after request (handshake)               
+	        if(valid)
+                  if (addr == `ADDR_CACHE_HIT)
+	            rdata <= hit_cnt;
+                  else if (addr == `ADDR_CACHE_MISS)
+	            rdata <= miss_cnt;
+	          else if (addr == `ADDR_CACHE_READ_HIT)
+	            rdata <= read_hit_cnt;
+	          else if (addr == `ADDR_CACHE_READ_MISS)
+	            rdata <= read_miss_cnt;
+	          else if (addr == `ADDR_CACHE_WRITE_HIT)
+	            rdata <= write_hit_cnt;
+	          else if (addr == `ADDR_CACHE_WRITE_MISS)
+	            rdata <= write_miss_cnt;
+	          else if (addr == `ADDR_RESET_COUNTER)
+	            counter_reset <= 1'b1;
+	          else if (addr == `ADDR_CACHE_INVALIDATE)
+	            invalidate <= 1'b1;	
+	          else if (addr == `ADDR_BUFFER_EMPTY)
+                    rdata <= wtbuf_empty;
+                  else if (addr == `ADDR_BUFFER_FULL)
+                    rdata <= wtbuf_full;   
+             end // always @ (posedge clk)
+        end // if (CTRL_CNT)
+      else
+        begin
+           
+           always @ (posedge clk)
+             begin
+	        rdata <= {FE_DATA_W{1'b0}};
+	        invalidate <= 1'b0;
+	        ready <= valid; // Sends acknowlege the next clock cycle after request (handshake)               
+	        if(valid)
+	          if (addr == `ADDR_CACHE_INVALIDATE)
+	            invalidate <= 1'b1;	
+	          else if (addr == `ADDR_BUFFER_EMPTY)
+                    rdata <= wtbuf_empty;
+                  else if (addr == `ADDR_BUFFER_FULL)
+                    rdata <= wtbuf_full;         
+             end // always @ (posedge clk)
+        end // else: !if(CTRL_CNT)  
+   endgenerate                
+   
+endmodule // cache_controller

--- a/hardware/src/cache-memory.v
+++ b/hardware/src/cache-memory.v
@@ -143,8 +143,8 @@ module cache_memory
      end
 
    //assign raw = write_hit_prev & (way_hit == way_hit) & (index_prev == index_reg) & (offset_prev == offset);//issue - currently a RAW in different indexes in the way-hit causes the read to read from the write addr.
-   assign raw = write_hit_prev;
-
+  // assign raw = write_hit_prev;
+   assign raw = write_hit_prev & (way_hit == way_hit) & (offset_prev == offset);
 
    
    assign hit = |way_hit & replace_ready & (~raw);//way_hit is also used during line replacement (to update that respective way). Hit is when there is a hit in a way and there isn't occuring a line-replacement (read-miss). 
@@ -242,7 +242,8 @@ module cache_memory
                                    .clk (clk),
                                    .en  (valid), 
                                    .we ({FE_NBYTES{way_hit[k]}} & line_wstrb[(j*(BE_DATA_W/FE_DATA_W)+i)*FE_NBYTES +: FE_NBYTES]),
-                                   .addr((write_access_reg & way_hit[k])? index_reg : index),
+                                  // .addr((write_access_reg & way_hit[k])? index_reg : index),
+                                   .addr((write_access_reg & way_hit[k] & ((j*(BE_DATA_W/FE_DATA_W)+i) == offset))? index_reg : index),
                                    // .data_in ((~replace_ready)? read_rdata[i*FE_DATA_W +: FE_DATA_W] : wdata_reg),
                                    .data_in ((write_access_reg)? wdata_reg : read_rdata[i*FE_DATA_W +: FE_DATA_W]),
                                    .data_out(line_rdata[(k*(2**WORD_OFF_W)+j*(BE_DATA_W/FE_DATA_W)+i)*FE_DATA_W +: FE_DATA_W])
@@ -350,7 +351,7 @@ module cache_memory
                               .clk (clk),
                               .en  (valid), 
                               .we ({FE_NBYTES{way_hit[k]}} & line_wstrb[i*FE_NBYTES +: FE_NBYTES]),
-                              .addr((write_access_reg & way_hit[k])? index_reg : index),
+                              .addr((write_access_reg & way_hit[k] & (i == offset))? index_reg : index),
                               .data_in ((write_access_reg)? wdata_reg : read_rdata[i*FE_DATA_W +: FE_DATA_W]),
                               .data_out(line_rdata[(k*(2**WORD_OFF_W)+i)*FE_DATA_W +: FE_DATA_W])
                               );
@@ -429,7 +430,7 @@ module cache_memory
                               .clk (clk),
                               .en  (valid), 
                               .we ({FE_NBYTES{way_hit}} & line_wstrb[(j*(BE_DATA_W/FE_DATA_W)+i)*FE_NBYTES +: FE_NBYTES]),
-                              .addr((write_access_reg & way_hit)? index_reg : index),
+                              .addr((write_access_reg & way_hit & ((j*(BE_DATA_W/FE_DATA_W)+i) == offset))? index_reg : index),
                               .data_in ((write_access_reg)? wdata_reg : read_rdata[i*FE_DATA_W +: FE_DATA_W]),
                               .data_out(line_rdata[(j*(BE_DATA_W/FE_DATA_W)+i)*FE_DATA_W +: FE_DATA_W])
                               );
@@ -502,7 +503,7 @@ module cache_memory
                          .clk (clk),
                          .en  (valid), 
                          .we ({FE_NBYTES{way_hit}} & line_wstrb[i*FE_NBYTES +: FE_NBYTES]),
-                         .addr((write_access_reg & way_hit)? index_reg : index),
+                         .addr((write_access_reg & way_hit & (i == offset))? index_reg : index),
                          .data_in ((write_access_reg)? wdata_reg : read_rdata[i*FE_DATA_W +: FE_DATA_W]),
                          .data_out(line_rdata[i*FE_DATA_W +: FE_DATA_W])
                          );

--- a/hardware/src/iob-cache-axi.v
+++ b/hardware/src/iob-cache-axi.v
@@ -30,7 +30,7 @@ module iob_cache_axi
     parameter [AXI_ID_W-1:0] AXI_ID = 0,  //AXI ID value
     //Controller's options
     parameter CTRL_CACHE = 0, //Adds a Controller to the cache, to use functions sent by the master or count the hits and misses
-    parameter CTRL_CNT = 0  //Counters for Cache Hits and Misses - Disabling this and previous, the Controller only store the buffer states and allows cache invalidation
+    parameter CTRL_CNT = 1  //Counters for Cache Hits and Misses - Disabling this and previous, the Controller only store the buffer states and allows cache invalidation
     ) 
    (
     input                                       clk,
@@ -169,7 +169,9 @@ module iob_cache_axi
        .LINE_OFF_W (LINE_OFF_W),
        .WORD_OFF_W (WORD_OFF_W),
        .REP_POLICY (REP_POLICY),    
-       .WTBUF_DEPTH_W (WTBUF_DEPTH_W)
+       .WTBUF_DEPTH_W (WTBUF_DEPTH_W),
+       .CTRL_CACHE(CTRL_CACHE),
+       .CTRL_CNT  (CTRL_CNT)
        )
    cache_memory
      (

--- a/hardware/src/iob-cache.v
+++ b/hardware/src/iob-cache.v
@@ -32,7 +32,7 @@ module iob_cache
   
     //Controller's options
     parameter CTRL_CACHE = 0, //Adds a Controller to the cache, to use functions sent by the master or count the hits and misses
-    parameter CTRL_CNT = 0  //Counters for Cache Hits and Misses - Disabling this and previous, the Controller only store the buffer states and allows cache invalidation
+    parameter CTRL_CNT = 1  //Counters for Cache Hits and Misses - Disabling this and previous, the Controller only store the buffer states and allows cache invalidation
     ) 
    (
     input                                       clk,
@@ -138,7 +138,9 @@ module iob_cache
        .LINE_OFF_W (LINE_OFF_W),
        .WORD_OFF_W (WORD_OFF_W),
        .REP_POLICY (REP_POLICY),    
-       .WTBUF_DEPTH_W (WTBUF_DEPTH_W)
+       .WTBUF_DEPTH_W (WTBUF_DEPTH_W),
+       .CTRL_CACHE(CTRL_CACHE),
+       .CTRL_CNT  (CTRL_CNT)
        )
    cache_memory
      (

--- a/hardware/testbench/iob-cache_tb.vh
+++ b/hardware/testbench/iob-cache_tb.vh
@@ -21,7 +21,7 @@
 
 
 //Cache Controller - select to remove it
-//`define NO_CTRL
+`define CTRL
 
 
 `define VCD

--- a/hardware/testbench/iob-cache_tb.vh
+++ b/hardware/testbench/iob-cache_tb.vh
@@ -1,7 +1,7 @@
 //Cache parameters (including front-end's)
-`define N_WAYS 1
+`define N_WAYS 2
 `define LINE_OFF_W 1
-`define WORD_OFF_W 2
+`define WORD_OFF_W 1
 `define ADDR_W 12
 `define DATA_W 32
 `define N_BYTES 4
@@ -23,11 +23,6 @@
 //Cache Controller - select to remove it
 //`define NO_CTRL
 
-//L2 Cache -- currently only works with `define AXI
-//`define L2 //Currently not working since addr only receives the word.
-
-// Look-ahead -- Uncomment to use
-`define LA
 
 `define VCD
 

--- a/hardware/testbench/pipeline-iob-cache_tb.v
+++ b/hardware/testbench/pipeline-iob-cache_tb.v
@@ -291,8 +291,8 @@ module iob_cache_tb;
                    .BE_ADDR_W(`MEM_ADDR_W),
                    .BE_DATA_W(`MEM_DATA_W),
                    .REP_POLICY(`REP_POLICY),
- `ifdef NO_CTRL
-                   .CTRL_CACHE(0),
+ `ifdef CTRL
+                   .CTRL_CACHE(1),
  `endif
                    .WTBUF_DEPTH_W(`WTBUF_DEPTH_W)
                    )
@@ -363,8 +363,8 @@ module iob_cache_tb;
                .BE_DATA_W(`MEM_DATA_W),
                .REP_POLICY(`REP_POLICY),
 
- `ifdef NO_CTRL
-               .CTRL_CACHE(0),
+ `ifdef CTRL
+               .CTRL_CACHE(1),
  `endif
                .WTBUF_DEPTH_W(`WTBUF_DEPTH_W)
                )

--- a/hardware/testbench/pipeline-iob-cache_tb.v
+++ b/hardware/testbench/pipeline-iob-cache_tb.v
@@ -133,10 +133,11 @@ module iob_cache_tb;
         addr <= 0;
         valid <=1;
         wstrb <=0;
-        #2
+        #20
           wstrb <= {`DATA_W/8{1'b1}};
         wdata <= 23434332205;
-        while (ready == 1'b0) #2;
+        //while (ready == 1'b0) #2;
+        #2;
         addr <= 1; //change of addr
         wstrb <= 0;
         #2
@@ -144,7 +145,7 @@ module iob_cache_tb;
         valid <= 0;
         #80;
 
-        
+        #80;
         
         $display("Cache testing completed\n");
         $finish;


### PR DESCRIPTION
RAW optimization in Cache-memory: only forces a delay in case the read-access is for the same offset and way (same block-ram). 
Fixed Cache-memory bugs:
- Correct implementation of optimized RAW prevention in the 4 available configurations;
- Correct implementation of hits and misses for Cache-Control.

Implementation of Cache-Control. Available for both with and without counters (hit-misses and access-types).

Submodules updated.