### PR TITLE
Back-End Write channel improvement; CTRL_IO invalidate and wtb_empty implementation

### DIFF
--- a/hardware/include/iob-cache.vh
+++ b/hardware/include/iob-cache.vh
@@ -2,6 +2,9 @@
 //Address-port
 `define WORD_ADDR // Word-addressable, (BE) addr becomes word-addressable (doesn't receive the byte-offset).
 
+//Control-ports
+`define CTRL_IO //ports that allow from outside signals to influence the invalidate and write-through buffer empty cache-control's functions.
+
 
 //Replacement Policy
 `define LRU       0 // Least Recently Used -- more resources intensive - N*log2(N) bits per cache line - Uses counters

--- a/hardware/testbench/iob-cache_tb.vh
+++ b/hardware/testbench/iob-cache_tb.vh
@@ -9,7 +9,7 @@
 `define REP_POLICY 0
 
 //Back-end Memory interface AXI or Native
-//`define AXI
+`define AXI
 
 //Cache back-end parameters
 `define MEM_ADDR_W 12

--- a/hardware/testbench/pipeline-iob-cache_tb.v
+++ b/hardware/testbench/pipeline-iob-cache_tb.v
@@ -305,6 +305,11 @@ module iob_cache_tb;
 	  .rdata (rdata),
 	  .valid (cpu_valid),
 	  .ready (ready),
+          //CTRL_IO
+          .force_inv_in(1'b0),
+          .force_inv_out(),
+          .wtb_empty_in(1'b1),
+          .wtb_empty_out(),
           //
 	  // AXI INTERFACE
           //
@@ -377,6 +382,11 @@ module iob_cache_tb;
 	  .rdata (rdata),
 	  .valid (cpu_valid),
 	  .ready (ready),
+          //CTRL_IO
+          .force_inv_in(1'b0),
+          .force_inv_out(),
+          .wtb_empty_in(1'b1),
+          .wtb_empty_out(),
           //
           // NATIVE MEMORY INTERFACE
           //

--- a/software/iob-cache.h
+++ b/software/iob-cache.h
@@ -6,16 +6,16 @@ static int cache_base;
 #define CACHEFUNC(cache_base, func) (*((volatile int*) (cache_base + (func * sizeof(int)))))
 
 //Function's memory map
-#define INVALIDATE      1
-#define BUFFER_EMPTY    2
-#define BUFFER_FULL     3
-#define HIT             4
-#define MISS            5
-#define READ_HIT        6
-#define READ_MISS       7
-#define WRITE_HIT       8
-#define WRITE_MISS      9
-#define COUNTER_RESET   10
+#define BUFFER_EMPTY    1
+#define BUFFER_FULL     2
+#define HIT             3
+#define MISS            4
+#define READ_HIT        5
+#define READ_MISS       6
+#define WRITE_HIT       7
+#define WRITE_MISS      8
+#define COUNTER_RESET   9
+#define INVALIDATE      10
 #define INSTR_HIT       11 //for CTRL_CNT_ID only
 #define INSTR_MISS      12 //for CTRL_CNT_ID only
 


### PR DESCRIPTION
- Improved Back-End write-channel for both Native and AXI (reduces consecutive writes by 1 clock-cycle
- Added define CTRL_IO that allows the implementation of a i/o forced invalidate signal (allowing a L1 to invalidate the L2), and a i/o for the write-buffer empty status (allowing for the L1 also return the fact the L2 is also empty). Mono-cache systems can disable this define in hardware/include/iob_cache.vh.