### PR TITLE
Back-End Write channel improvement; CTRL_IO invalidate and wtb_empty implementation

### DIFF
--- a/hardware/include/iob-cache.vh
+++ b/hardware/include/iob-cache.vh
@@ -3,7 +3,7 @@
 `define WORD_ADDR // Word-addressable, (BE) addr becomes word-addressable (doesn't receive the byte-offset).
 
 //Control-ports
-//`define CTRL_IO //ports that allow from outside signals to influence the invalidate and write-through buffer empty cache-control's functions.
+`define CTRL_IO //ports that allow from outside signals to influence the invalidate and write-through buffer empty cache-control's functions.
 
 
 //Replacement Policy

--- a/hardware/include/iob-cache.vh
+++ b/hardware/include/iob-cache.vh
@@ -2,6 +2,9 @@
 //Address-port
 `define WORD_ADDR // Word-addressable, (BE) addr becomes word-addressable (doesn't receive the byte-offset).
 
+//Control-ports
+`define CTRL_IO //ports that allow from outside signals to influence the invalidate and write-through buffer empty cache-control's functions.
+
 
 //Replacement Policy
 `define LRU       0 // Least Recently Used -- more resources intensive - N*log2(N) bits per cache line - Uses counters

--- a/hardware/include/iob-cache.vh
+++ b/hardware/include/iob-cache.vh
@@ -3,7 +3,7 @@
 `define WORD_ADDR // Word-addressable, (BE) addr becomes word-addressable (doesn't receive the byte-offset).
 
 //Control-ports
-`define CTRL_IO //ports that allow from outside signals to influence the invalidate and write-through buffer empty cache-control's functions.
+//`define CTRL_IO //ports that allow from outside signals to influence the invalidate and write-through buffer empty cache-control's functions.
 
 
 //Replacement Policy

--- a/hardware/src/cache-memory.v
+++ b/hardware/src/cache-memory.v
@@ -274,7 +274,10 @@ endgenerate
 
                      
                      always @(posedge clk)
-                       v[k] <= v_reg [(2**LINE_OFF_W)*k + index];
+                       if(invalidate)
+                         v[k] <= 0;
+                       else
+                         v[k] <= v_reg [(2**LINE_OFF_W)*k + index];
                      
                      
                      iob_sp_ram
@@ -378,10 +381,11 @@ endgenerate
                               );
                        end // for (i = 0; i < 2**WORD_OFF_W; i=i+1)
 
-                     
                      always @(posedge clk)
-                       v[k] <= v_reg [(2**LINE_OFF_W)*k + index];
-                     
+                       if(invalidate)
+                         v[k] <= 0;
+                       else
+                         v[k] <= v_reg [(2**LINE_OFF_W)*k + index];
                      
                      iob_sp_ram
                        #(
@@ -460,7 +464,10 @@ endgenerate
 
                 
                 always @(posedge clk)
-                  v <= v_reg [index];
+                  if(invalidate)
+                    v <= 0;
+                  else
+                    v <= v_reg [index];
                 
                 
                 iob_sp_ram
@@ -532,7 +539,10 @@ endgenerate
 
                 
                 always @(posedge clk)
-                  v <= v_reg [index];
+                  if(invalidate)
+                    v <= 0;
+                  else
+                    v <= v_reg [index];
                 
                 
                 iob_sp_ram

--- a/hardware/src/front-end.v
+++ b/hardware/src/front-end.v
@@ -121,8 +121,6 @@ module front_end
    
    
    assign data_addr  = addr[FE_ADDR_W-1:FE_BYTE_W];
-   //assign data_wdata = wdata;
-   //assign data_wstrb = wstrb;
    assign data_valid = valid_int | valid_reg;
    
    assign data_addr_reg  = addr_reg[FE_ADDR_W-1:FE_BYTE_W];

--- a/hardware/testbench/iob-cache_tb.vh
+++ b/hardware/testbench/iob-cache_tb.vh
@@ -9,7 +9,7 @@
 `define REP_POLICY 0
 
 //Back-end Memory interface AXI or Native
-//`define AXI
+`define AXI
 
 //Cache back-end parameters
 `define MEM_ADDR_W 12

--- a/hardware/testbench/pipeline-iob-cache_tb.v
+++ b/hardware/testbench/pipeline-iob-cache_tb.v
@@ -305,6 +305,11 @@ module iob_cache_tb;
 	  .rdata (rdata),
 	  .valid (cpu_valid),
 	  .ready (ready),
+          //CTRL_IO
+          .force_inv_in(1'b0),
+          .force_inv_out(),
+          .wtb_empty_in(1'b1),
+          .wtb_empty_out(),
           //
 	  // AXI INTERFACE
           //
@@ -377,6 +382,11 @@ module iob_cache_tb;
 	  .rdata (rdata),
 	  .valid (cpu_valid),
 	  .ready (ready),
+          //CTRL_IO
+          .force_inv_in(1'b0),
+          .force_inv_out(),
+          .wtb_empty_in(1'b1),
+          .wtb_empty_out(),
           //
           // NATIVE MEMORY INTERFACE
           //

--- a/hardware/testbench/pipeline-iob-cache_tb.v
+++ b/hardware/testbench/pipeline-iob-cache_tb.v
@@ -16,8 +16,7 @@ module iob_cache_tb;
    reg                                 valid=0;
    wire [`DATA_W-1:0]                  rdata;
    wire                                ready;
-   reg                                 instr =0;
-   wire                                select = 0;//cache is always selected
+   reg                                 ctrl =0;
    wire                                i_select =0, d_select =0;
    reg [31:0]                          test = 0;
    reg                                 pipe_en = 0;
@@ -104,10 +103,10 @@ module iob_cache_tb;
         addr <= 0;
         valid <=1;
         wstrb <=0;
-        #2
-          wstrb <= {`DATA_W/8{1'b1}};
+        #2;
+        wstrb <= {`DATA_W/8{1'b1}};
         wdata <= 57005;
-        while (ready == 1'b0) #2;
+        #2;
         wstrb <= 0;
         #2
           while (ready == 1'b0) #2;
@@ -145,8 +144,21 @@ module iob_cache_tb;
         valid <= 0;
         #80;
 
+       
+        $display("Test 7 - Testing cache-invalidate (r-inv-r)\n");
+        test <= 7;
+        addr <= 0;
+        valid <=1;
+        wstrb <=0;
+        while (ready == 1'b0) #2;
+        ctrl <=1;  //ctrl function
+        addr <= 10;//invalidate
+        valid <=1;
+        #2;
+        while (ready == 1'b0) #2;
+        ctrl <=0;
+        addr <=0;
         #80;
-        
         $display("Cache testing completed\n");
         $finish;
      end // initial begin
@@ -291,16 +303,14 @@ module iob_cache_tb;
                    .BE_ADDR_W(`MEM_ADDR_W),
                    .BE_DATA_W(`MEM_DATA_W),
                    .REP_POLICY(`REP_POLICY),
- `ifdef CTRL
                    .CTRL_CACHE(1),
- `endif
                    .WTBUF_DEPTH_W(`WTBUF_DEPTH_W)
                    )
    cache (
 	  .clk (clk),
 	  .reset (reset),
 	  .wdata (cpu_wdata),
-	  .addr  (cpu_addr),
+	  .addr  ({ctrl,cpu_addr}),
 	  .wstrb (cpu_wstrb),
 	  .rdata (rdata),
 	  .valid (cpu_valid),
@@ -367,17 +377,14 @@ module iob_cache_tb;
                .BE_ADDR_W(`MEM_ADDR_W),
                .BE_DATA_W(`MEM_DATA_W),
                .REP_POLICY(`REP_POLICY),
-
- `ifdef CTRL
                .CTRL_CACHE(1),
- `endif
                .WTBUF_DEPTH_W(`WTBUF_DEPTH_W)
                )
    cache (
 	  .clk (clk),
 	  .reset (reset),
 	  .wdata (cpu_wdata),
-	  .addr  (cpu_addr),
+	  .addr  ({ctrl,cpu_addr}),
 	  .wstrb (cpu_wstrb),
 	  .rdata (rdata),
 	  .valid (cpu_valid),

--- a/software/iob-cache.c
+++ b/software/iob-cache.c
@@ -29,6 +29,3 @@ int cache_write_miss()   {return (CACHEFUNC(cache_base,WRITE_MISS));}
 
 int cache_counter_reset(){return (CACHEFUNC(cache_base,COUNTER_RESET));}
 
-int cache_instr_hit()    {return (CACHEFUNC(cache_base,INSTR_HIT));}
-
-int cache_instr_miss()   {return (CACHEFUNC(cache_base,INSTR_MISS));}

--- a/software/iob-cache.h
+++ b/software/iob-cache.h
@@ -6,16 +6,16 @@ static int cache_base;
 #define CACHEFUNC(cache_base, func) (*((volatile int*) (cache_base + (func * sizeof(int)))))
 
 //Function's memory map
-#define INVALIDATE      1
-#define BUFFER_EMPTY    2
-#define BUFFER_FULL     3
-#define HIT             4
-#define MISS            5
-#define READ_HIT        6
-#define READ_MISS       7
-#define WRITE_HIT       8
-#define WRITE_MISS      9
-#define COUNTER_RESET   10
+#define BUFFER_EMPTY    1
+#define BUFFER_FULL     2
+#define HIT             3
+#define MISS            4
+#define READ_HIT        5
+#define READ_MISS       6
+#define WRITE_HIT       7
+#define WRITE_MISS      8
+#define COUNTER_RESET   9
+#define INVALIDATE      10
 #define INSTR_HIT       11 //for CTRL_CNT_ID only
 #define INSTR_MISS      12 //for CTRL_CNT_ID only
 

--- a/software/iob-cache.h
+++ b/software/iob-cache.h
@@ -16,8 +16,6 @@ static int cache_base;
 #define WRITE_MISS      8
 #define COUNTER_RESET   9
 #define INVALIDATE      10
-#define INSTR_HIT       11 //for CTRL_CNT_ID only
-#define INSTR_MISS      12 //for CTRL_CNT_ID only
 
 // Cache Controllers's functions
 void cache_init(int ext_mem, int cache_addr); // initialized the cache_base static integer
@@ -30,6 +28,4 @@ int cache_read_hit();
 int cache_read_miss(); 
 int cache_write_hit();  
 int cache_write_miss();  
-int cache_counter_reset();  
-int cache_instr_hit();       
-int cache_instr_miss();
+int cache_counter_reset();


### PR DESCRIPTION
Improved Back-End write-channel for both Native and AXI (reduces consecutive writes by 1 clock-cycle
Added define CTRL_IO that allows the implementation of a i/o forced invalidate signal (allowing a L1 to invalidate the L2), and a i/o for the write-buffer empty status (allowing for the L1 also return the fact the L2 is also empty). Mono-cache systems can disable this define in hardware/include/iob_cache.vh.