### PR TITLE
Initial verilator simulation

### DIFF
--- a/hardware/simulation/verilator/Makefile
+++ b/hardware/simulation/verilator/Makefile
@@ -1,0 +1,29 @@
+#module paths
+CACHE_DIR:=../../..
+incdir:=-I
+defmacro:=-D
+
+include $(CACHE_DIR)/hardware/hardware.mk
+
+#headers
+VHDR+=../testbench/iob-cache_tb.vh
+
+#sources
+VSRC+=$(AXIMEM_DIR)/rtl/axi_ram.v
+
+INCLUDE=$(incdir)$(CACHE_INC_DIR)
+INCLUDE+=$(incdir)../testbench
+
+include $(MEM_DIR)/config.mk
+$(foreach p, $(MEM_MODULES), $(eval include $(MEM_DIR)/hardware/$(p)/hardware.mk))
+
+all: $(VSRC) testbench.cpp
+	verilator -Wno-WIDTH --trace --cc --exe $(INCLUDE) $(VSRC) testbench.cpp --top-module iob_cache
+	cd ./obj_dir && make -f Viob_cache.mk
+	./obj_dir/Viob_cache
+
+clean:
+	rm -r ./obj_dir
+	rm vcd.vcd
+
+.PHONY: all clean

--- a/hardware/simulation/verilator/testbench.cpp
+++ b/hardware/simulation/verilator/testbench.cpp
@@ -1,0 +1,53 @@
+#include <verilated.h>
+#include <verilated_vcd_c.h>
+#include <iostream>
+
+#include "obj_dir/Viob_cache.h"
+
+int main(int argc, char** argv) {
+    std::cout << "Iob_cache simulation start" << std::endl;
+
+    Verilated::commandArgs(argc, argv);
+    Verilated::traceEverOn(true);
+
+    Viob_cache* tb = new Viob_cache;
+    VerilatedVcdC* tfp = new VerilatedVcdC;
+
+    tb->trace(tfp,99); // Trace 99 levels of hierarchy
+    tb->reset = 0;
+
+    tfp->open("vcd.vcd");
+
+    int main_time = 0;
+    while (!Verilated::gotFinish()) {
+        if (main_time > 10) {
+            tb->reset = 1;
+        }
+        if ((main_time % 10) == 1) {
+            tb->clk = 1;
+        }
+        if ((main_time % 10) == 6) {
+            tb->clk = 0;
+        }
+        tb->eval();
+        tfp->dump(main_time);
+        main_time++;
+
+        // Stop after a set time, since otherwise the current design would simulate forever
+        if(main_time > 100){
+            break;
+        }
+    }
+
+    tb->final();
+    tfp->dump(main_time);
+
+    tfp->close();
+
+    delete tb;
+    delete tfp;
+
+    std::cout << "Iob_cache simulation end" << std::endl;
+
+    return 0;
+}

--- a/hardware/simulation/verilator/testbench.cpp
+++ b/hardware/simulation/verilator/testbench.cpp
@@ -7,16 +7,17 @@
 int main(int argc, char** argv) {
     std::cout << std::endl << "Iob_cache simulation start" << std::endl;
 
+    // Init verilator context and enable tracing
     Verilated::commandArgs(argc, argv);
     Verilated::traceEverOn(true);
 
-    Viob_cache* tb = new Viob_cache;
-    VerilatedVcdC* tfp = new VerilatedVcdC;
+    Viob_cache* tb = new Viob_cache; // Create UUT
+    VerilatedVcdC* tfp = new VerilatedVcdC; // Create tracing object
 
     tb->trace(tfp,99); // Trace 99 levels of hierarchy
-    tb->reset = 0;
+    tfp->open("vcd.vcd"); // Open tracing file
 
-    tfp->open("vcd.vcd");
+    tb->reset = 0; // Init wire to initial value
 
     int main_time = 0;
     while (!Verilated::gotFinish()) {
@@ -30,7 +31,7 @@ int main(int argc, char** argv) {
             tb->clk = 0;
         }
         tb->eval();
-        tfp->dump(main_time);
+        tfp->dump(main_time); // Dump values into tracing file
         main_time++;
 
         // Stop after a set time, since otherwise the current design would simulate forever
@@ -40,9 +41,9 @@ int main(int argc, char** argv) {
     }
 
     tb->final();
-    tfp->dump(main_time);
+    tfp->dump(main_time); // Dump last values
 
-    tfp->close();
+    tfp->close(); // Close tracing file
 
     std::cout << "Generated vcd file" << std::endl;
 

--- a/hardware/simulation/verilator/testbench.cpp
+++ b/hardware/simulation/verilator/testbench.cpp
@@ -5,7 +5,7 @@
 #include "obj_dir/Viob_cache.h"
 
 int main(int argc, char** argv) {
-    std::cout << "Iob_cache simulation start" << std::endl;
+    std::cout << std::endl << "Iob_cache simulation start" << std::endl;
 
     Verilated::commandArgs(argc, argv);
     Verilated::traceEverOn(true);
@@ -44,10 +44,12 @@ int main(int argc, char** argv) {
 
     tfp->close();
 
+    std::cout << "Generated vcd file" << std::endl;
+
     delete tb;
     delete tfp;
 
-    std::cout << "Iob_cache simulation end" << std::endl;
+    std::cout << "Iob_cache simulation end" << std::endl << std::endl;
 
     return 0;
 }


### PR DESCRIPTION
Go to hardware/simulation/verilator and do "make all" to do the simulation.

There are errors but those occur from the MEM submodule. I removed them to run the test but of course someone else should fix them. 

With the errors removed, the simulation runs and produces a vcd file, called vcd.vcd.

Extra files are generated and can be cleaned by doing "make clean".

Important note: The reason that on the Makefile lines 14 and 15 are there is because the Verilator include is really picky with the spaces between the incdir (-I) and the path. For example, if I have a path that is /dir/, I cannot do "-I /dir/", because of the extra space, I have to do "-I/dir/".