### PR TITLE
rename VCD file

### DIFF
--- a/hardware/simulation/testbench/iob-cache_tb.v
+++ b/hardware/simulation/testbench/iob-cache_tb.v
@@ -26,7 +26,7 @@ module iob_cache_tb;
      begin
         
 `ifdef VCD
-	$dumpfile("uut.vcd");
+	$dumpfile("cache.vcd");
 	$dumpvars();
 `endif  
         repeat (5) @(posedge clk);

--- a/hardware/simulation/testbench/pipeline-iob-cache_tb.v
+++ b/hardware/simulation/testbench/pipeline-iob-cache_tb.v
@@ -31,7 +31,7 @@ module iob_cache_tb;
      begin
         
 `ifdef VCD
-	$dumpfile("uut.vcd");
+	$dumpfile("cache.vcd");
 	$dumpvars();
 `endif  
         repeat (5) @(posedge clk);


### PR DESCRIPTION
cache.vcd instead of uut.vcd
Can be used no matter whether or not the scope is limited to the unit under test.