### PR TITLE
update simulation/icarus Makefile

### DIFF
--- a/hardware/simulation/icarus/Makefile
+++ b/hardware/simulation/icarus/Makefile
@@ -15,12 +15,23 @@ TB ?= $(CACHE_TB_DIR)/pipeline-iob-cache_tb.v
 #icarus verilog simulator
 VLOG = 	iverilog -W all -g2005-sv
 
-run: a.out
+run: 
+
+ifeq ($(VCD), 0)
+run:a.out
 	./$<
-ifeq ($(VCD),1)
-	if [ "`pgrep -u $(USER) gtkwave`" ]; then killall -q -9 gtkwave; fi
-	gtkwave -a ../waves.gtkw uut.vcd &
 endif
+
+ifeq ($(VCD), 1)
+run:a.out
+	./$<
+endif
+
+ifeq ($(VCD),2)	
+run:	
+	if [ "`pgrep -u $(USER) gtkwave`" ]; then killall -q -9 gtkwave; fi
+	gtkwave uut.vcd &
+endif 
 
 a.out: $(VSRC) $(VHDR)
 	$(VLOG) $(INCLUDE) $(DEFINE) $(VSRC)
@@ -28,4 +39,4 @@ a.out: $(VSRC) $(VHDR)
 clean:
 	@rm -f *# *~ *.vcd a.out *_tb
 
-.PHONY: run clean
+.PHONY: a.out run clean

--- a/hardware/simulation/simulation.mk
+++ b/hardware/simulation/simulation.mk
@@ -20,8 +20,3 @@ VHDR+=$(CACHE_TB_DIR)/iob-cache_tb.vh
 VSRC+=$(TB)
 #other sources
 VSRC+=$(AXIMEM_DIR)/rtl/axi_ram.v
-
-waves:
-	gtkwave uut.vcd
-
-.PHONY: waves


### PR DESCRIPTION
Update simulation/icarus/Makefile as follows:
- reorganize run target to get three separate options
1. make sim: run simulation without generating a VCD file
2. make sim VCD=1: run simulation with generating a VCD file
3. make sim VCD=2: visualize waveforms, this assumes that a vcd file has been already generated. 
- force the makefile to rebuild a.out target
