### PR TITLE
remove SIMULATOR variable from icarus/ and verilator/ Makefile

### DIFF
--- a/hardware/simulation/icarus/Makefile
+++ b/hardware/simulation/icarus/Makefile
@@ -8,7 +8,7 @@ include ../simulation.mk
 
 #testbench
 TB ?= $(CACHE_TB_DIR)/pipeline-iob-cache_tb.v
-#TB ?=$(CACHE_TB_DIR)/rep_pol_tb.v"
+#TB ?=$(CACHE_TB_DIR)/rep_pol_tb.v
 
 #icarus verilog simulator
 VLOG = 	iverilog -W all -g2005-sv

--- a/hardware/simulation/icarus/Makefile
+++ b/hardware/simulation/icarus/Makefile
@@ -4,34 +4,21 @@ CACHE_DIR:=../../..
 incdir:=-I
 defmacro:=-D
 
-SIMULATOR=icarus
-
 include ../simulation.mk
 
 #testbench
 TB ?= $(CACHE_TB_DIR)/pipeline-iob-cache_tb.v
-#TB ?=$(CACHE_TB_DIR)/rep_pol_tb.v
+#TB ?=$(CACHE_TB_DIR)/rep_pol_tb.ve"
 
 #icarus verilog simulator
 VLOG = 	iverilog -W all -g2005-sv
 
-run: 
-
-ifeq ($(VCD), 0)
-run:a.out
+run: a.out
 	./$<
-endif
-
-ifeq ($(VCD), 1)
-run:a.out
-	./$<
-endif
-
-ifeq ($(VCD),2)	
-run:	
+ifeq ($(VCD),1)
 	if [ "`pgrep -u $(USER) gtkwave`" ]; then killall -q -9 gtkwave; fi
-	gtkwave uut.vcd &
-endif 
+	gtkwave -a ../waves.gtkw uut.vcd &
+endif
 
 a.out: $(VSRC) $(VHDR)
 	$(VLOG) $(INCLUDE) $(DEFINE) $(VSRC)
@@ -39,4 +26,4 @@ a.out: $(VSRC) $(VHDR)
 clean:
 	@rm -f *# *~ *.vcd a.out *_tb
 
-.PHONY: a.out run clean
+.PHONY: run clean

--- a/hardware/simulation/icarus/Makefile
+++ b/hardware/simulation/icarus/Makefile
@@ -15,12 +15,23 @@ TB ?= $(CACHE_TB_DIR)/pipeline-iob-cache_tb.v
 #icarus verilog simulator
 VLOG = 	iverilog -W all -g2005-sv
 
-run: a.out
+run: 
+
+ifeq ($(VCD), 0)
+run:a.out
 	./$<
-ifeq ($(VCD),1)
-	if [ "`pgrep -u $(USER) gtkwave`" ]; then killall -q -9 gtkwave; fi
-	gtkwave -a ../waves.gtkw uut.vcd &
 endif
+
+ifeq ($(VCD), 1)
+run:a.out
+	./$<
+endif
+
+ifeq ($(VCD),2)	
+run:	
+	if [ "`pgrep -u $(USER) gtkwave`" ]; then killall -q -9 gtkwave; fi
+	gtkwave uut.vcd &
+endif 
 
 a.out: $(VSRC) $(VHDR)
 	$(VLOG) $(INCLUDE) $(DEFINE) $(VSRC)
@@ -28,4 +39,4 @@ a.out: $(VSRC) $(VHDR)
 clean:
 	@rm -f *# *~ *.vcd a.out *_tb
 
-.PHONY: run clean
+.PHONY: a.out run clean

--- a/hardware/simulation/icarus/Makefile
+++ b/hardware/simulation/icarus/Makefile
@@ -8,7 +8,7 @@ include ../simulation.mk
 
 #testbench
 TB ?= $(CACHE_TB_DIR)/pipeline-iob-cache_tb.v
-#TB ?=$(CACHE_TB_DIR)/rep_pol_tb.ve"
+#TB ?=$(CACHE_TB_DIR)/rep_pol_tb.v"
 
 #icarus verilog simulator
 VLOG = 	iverilog -W all -g2005-sv

--- a/hardware/simulation/simulation.mk
+++ b/hardware/simulation/simulation.mk
@@ -20,8 +20,3 @@ VHDR+=$(CACHE_TB_DIR)/iob-cache_tb.vh
 VSRC+=$(TB)
 #other sources
 VSRC+=$(AXIMEM_DIR)/rtl/axi_ram.v
-
-waves:
-	gtkwave uut.vcd
-
-.PHONY: waves

--- a/hardware/simulation/simulation.mk
+++ b/hardware/simulation/simulation.mk
@@ -20,3 +20,8 @@ VHDR+=$(CACHE_TB_DIR)/iob-cache_tb.vh
 VSRC+=$(TB)
 #other sources
 VSRC+=$(AXIMEM_DIR)/rtl/axi_ram.v
+
+waves:
+	gtkwave uut.vcd
+
+.PHONY: waves

--- a/hardware/simulation/verilator/Makefile
+++ b/hardware/simulation/verilator/Makefile
@@ -4,8 +4,6 @@ CACHE_DIR:=../../..
 incdir:=-I
 defmacro:=-D
 
-SIMULATOR=verilator
-
 include ../simulation.mk
 
 TB=testbench.cpp


### PR DESCRIPTION
It is already defined in config.mk