### PR TITLE
use iob_cache_iob top module to generate the ug.pdf; fix some doc generation issues

### DIFF
--- a/hardware/src/iob_cache_iob.v
+++ b/hardware/src/iob_cache_iob.v
@@ -43,9 +43,9 @@ module iob_cache_iob
     `IOB_OUTPUT(invalidate_out,1), //This output is asserted high whenever the cache is invalidated.
     `IOB_INPUT(wtb_empty_in,1), //This input may be driven the next-level cache, when its write-through buffer is empty. It should be tied to high if there no next-level cache.
     `IOB_OUTPUT(wtb_empty_out,1), //This output is high if the cache's write-through buffer is empty and the {\tt wtb_empty_in} signal is high.
+    
     //General Interface Signals
-    `IOB_INPUT(clk,          1), //System clock input
-    `IOB_INPUT(rst,          1)  //System reset, asynchronous and active high
+    `include "iob_gen_if.vh"
     );
 
    //BLOCK Front-end & Front-end interface.

--- a/info.mk
+++ b/info.mk
@@ -3,7 +3,7 @@ NAME=iob_cache
 # core version 
 VERSION=0010
 # top-leel module
-TOP_MODULE?=iob_cache_axi
-#TOP_MODULE?=iob_cache_iob
+TOP_MODULE?=iob_cache_iob
+#TOP_MODULE?=iob_cache_axi
 # core path as seen from LIB's makefile
 CACHE_DIR=$(CORE_DIR)


### PR DESCRIPTION
Set the top module by default to iob_cache_iob to generate the ug.pdf
Note: AXI i/f is retrieved from iob_cache_axi_m_port.vh