### PR TITLE
fix(sim): update LIB, sim sources to hw/sim

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: 'recursive'
-      - name: test-clean
+      - name: setup
         run: make setup
       - name: test-sim
-        run: make -C iob_uart_V0.10/ sim-test
+        run: make -C iob_cache_V0.10/ sim-test
   fpga:
     runs-on: self-hosted
     timeout-minutes: 10
@@ -41,10 +41,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: 'recursive'
-      - name: test-clean
+      - name: setup
         run: make setup
       - name: test-fpga
-        run: make -C iob_uart_V0.10/ fpga-test
+        run: make -C iob_cache_V0.10/ fpga-test
   doc:
     runs-on: self-hosted
     timeout-minutes: 10
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: 'recursive'
-      - name: test-clean
+      - name: setup
         run: make setup
       - name: test-doc
-        run: make -C iob_uart_V0.10/ doc-test
+        run: make -C iob_cache_V0.10/ doc-test

--- a/hardware/simulation/sim_setup.mk
+++ b/hardware/simulation/sim_setup.mk
@@ -3,9 +3,9 @@
 #
 
 # copy simulation wrapper
-VSRC+=$(BUILD_VSRC_DIR)/iob_cache_wrapper.v
-$(BUILD_VSRC_DIR)/iob_cache_wrapper.v: $(CORE_SIM_DIR)/iob_cache_wrapper.v
-	cp $< $(BUILD_VSRC_DIR)
+VSRC+=$(BUILD_SIM_DIR)/iob_cache_wrapper.v
+$(BUILD_SIM_DIR)/iob_cache_wrapper.v: $(CORE_SIM_DIR)/iob_cache_wrapper.v
+	cp $< $(BUILD_SIM_DIR)
 
 # copy external memory for iob interface
 include hardware/ram/iob_ram_sp_be/hardware.mk
@@ -14,7 +14,7 @@ include hardware/ram/iob_ram_sp_be/hardware.mk
 include hardware/axiram/hardware.mk
 
 # generate and copy AXI4 wires to connect cache to axi memory
-VHDR+=$(BUILD_VSRC_DIR)/iob_cache_axi_wire.vh
-$(BUILD_VSRC_DIR)/iob_cache_axi_wire.vh:
+VHDR+=$(BUILD_SIM_DIR)/iob_cache_axi_wire.vh
+$(BUILD_SIM_DIR)/iob_cache_axi_wire.vh:
 	./software/python/axi_gen.py axi_wire iob_cache_
-	mv $(subst $(BUILD_VSRC_DIR)/, , $@) $(BUILD_VSRC_DIR)
+	mv $(subst $(BUILD_SIM_DIR)/, , $@) $(BUILD_SIM_DIR)

--- a/hardware/simulation/simulation.mk
+++ b/hardware/simulation/simulation.mk
@@ -12,6 +12,9 @@ else
 	touch $@
 endif
 
+# Add simulation specific sources
+VSRC+=iob_cache_wrapper.v
+
 #verilator top module
 VTOP:=iob_cache_wrapper
 
@@ -31,3 +34,6 @@ test3: test.log
 TEST_LIST+=test4
 test4: test.log
 	make clean SIMULATOR=verilator && make run SIMULATOR=verilator TOP_MODULE=iob_cache_axi
+
+NOCLEAN+=-o -name "iob_cache_wrapper.v"
+NOCLEAN+=-o -name "iob_cache_axi_wire.vh"

--- a/hardware/src/iob_cache_write_channel.v
+++ b/hardware/src/iob_cache_write_channel.v
@@ -1,5 +1,6 @@
 `timescale 1ns / 1ps
 
+`include "iob_cache_conf.vh"
 `include "iob_cache.vh"
 
 module iob_cache_write_channel


### PR DESCRIPTION
- update LIB submodule
- copy simulation specific sources to `BUILD_DIR/hw/sim` during setup
- add simulation specific sources in `simulation.mk` to `VSRC` and to
  `NOCLEAN` variable to exclude from simulation `clean` target
- this ensures that `BUILD_DIR/hw/vsrc` has no simulation specific
  sources
- this pattern could be further applied to the testbench sources `*_tb.v`:
  - add `*_tb.v` to be copied to `BUILD_DIR/hw/sim` during `setup` in `sim_setup.mk`
  - add `*_tb.v` files to `NOCLEAN` in `simulation.mk` 