### PR TITLE
Update LIB Submodule

### DIFF
--- a/hardware/simulation/iob_cache_sim_wrapper.v
+++ b/hardware/simulation/iob_cache_sim_wrapper.v
@@ -42,7 +42,7 @@ module iob_cache_sim_wrapper
     `IOB_OUTPUT(wtb_empty_out,1),
 
    //General Interface Signals
-`include "iob_gen_if.vh" 
+`include "iob_clkrst_port.vh" 
    );	
 
 `ifdef AXI
@@ -97,8 +97,8 @@ module iob_cache_sim_wrapper
       .be_req(be_req),
       .be_ack(be_ack),
 `endif
-      .clk (clk),
-      .rst (rst)
+      .clk_i (clk_i),
+      .rst_i (rst_i)
         );
 
 `ifdef AXI  
@@ -112,8 +112,8 @@ module iob_cache_sim_wrapper
    axi_ram
      (
  `include "iob_cache_ram_axi_portmap.vh"
-      .clk            (clk),
-      .rst            (rst)
+      .clk            (clk_i),
+      .rst            (rst_i)
       );
 `else
    iob_ram_sp_be 
@@ -123,7 +123,7 @@ module iob_cache_sim_wrapper
        )
    native_ram
      (
-      .clk(clk),
+      .clk(clk_i),
       .en  (be_req),
       .we  (be_wstrb),
       .addr(be_addr),
@@ -131,8 +131,8 @@ module iob_cache_sim_wrapper
       .din (be_wdata)
       );
 
-   always @(posedge clk, posedge rst)
-     if(rst) 
+   always @(posedge clk_i, posedge rst_i)
+     if(rst_i) 
        be_ack <= 1'b0;
      else
        be_ack <= be_req;

--- a/hardware/simulation/iob_cache_tb.cpp
+++ b/hardware/simulation/iob_cache_tb.cpp
@@ -28,13 +28,13 @@ int main(int argc, char** argv) {
     tfp->open("uut.vcd");  //Open tracing file
 #endif
 
-    dut->clk=1; dut->rst=0;    
+    dut->clk_i=1; dut->rst_i=0;    
     while (main_time < MAX_SIM_TIME) {
-        dut->clk=!dut->clk;  
-        dut->rst=(main_time >=1 && main_time <= 8) ? 1 : 0; 	
+        dut->clk_i=!dut->clk_i;  
+        dut->rst_i=(main_time >=1 && main_time <= 8) ? 1 : 0; 	
         dut->eval();
 
-        if(dut->clk == 1) {
+        if(dut->clk_i == 1) {
 	  posedge_cnt++; 
 
 	  //if(posedge_cnt == 7) VL_PRINTF("IOb-Cache Version: %d\n", cache_version());

--- a/hardware/simulation/iob_cache_tb.v
+++ b/hardware/simulation/iob_cache_tb.v
@@ -77,8 +77,8 @@ module iob_cache_tb;
       .wtb_empty_in(1'b1),
       .wtb_empty_out(),
 
-      .clk(clk),
-      .rst(rst)
+      .clk_i(clk),
+      .rst_i(rst)
       );
    
 endmodule

--- a/hardware/src/iob_cache.v
+++ b/hardware/src/iob_cache.v
@@ -55,7 +55,7 @@ module iob_cache
     `IOB_INPUT(wtb_empty_in,1), //This input is driven by the next-level cache, if there is one, when its write-through buffer is empty. It should be tied high if there is no next-level cache. This signal is used to compute the overall empty status of a cache hierarchy, as explained for signal {\tt wtb_empty_out}.
     `IOB_OUTPUT(wtb_empty_out,1), //This output is high if the cache's write-through buffer is empty and its {\tt wtb_empty_in} signal is high. This signal informs that all data written to the cache has been written to the destination memory module, and all caches on the way are empty.
    //General Interface Signals
-`include "iob_gen_if.vh" 
+`include "iob_clkrst_port.vh" 
    );	
 
 `ifdef AXI   
@@ -107,8 +107,8 @@ module iob_cache
         .be_req(be_req),
         .be_ack(be_ack),
 `endif
-        .clk (clk),
-        .rst (rst)
+        .clk_i (clk_i),
+        .rst_i (rst_i)
         );
 
 endmodule

--- a/hardware/src/iob_cache_axi.v
+++ b/hardware/src/iob_cache_axi.v
@@ -81,7 +81,7 @@ module iob_cache_axi
        )
    front_end
      (
-      .clk   (clk_i),
+      .clk_i   (clk_i),
       .reset (rst_i),
 
       // front-end port
@@ -146,7 +146,7 @@ module iob_cache_axi
        )
    cache_memory
      (
-      .clk   (clk_i),
+      .clk_i   (clk_i),
       .reset (rst_i),
 
       // front-end
@@ -233,7 +233,7 @@ module iob_cache_axi
             )
       cache_control
         (
-         .clk   (clk_i),
+         .clk_i   (clk_i),
          .reset (rst_i),
 
          // control's signals

--- a/hardware/src/iob_cache_axi.v
+++ b/hardware/src/iob_cache_axi.v
@@ -49,8 +49,8 @@ module iob_cache_axi
     // AXI4 back-end interface
 `include "iob_cache_axi_m_port.vh"
     //General Interface Signals
-    `IOB_INPUT(clk,          1), //System clock input
-    `IOB_INPUT(rst,          1)  //System reset, asynchronous and active high
+    `IOB_INPUT(clk_i,          1), //System clock input
+    `IOB_INPUT(rst_i,          1)  //System reset, asynchronous and active high
     );
    
    //Front-end & Front-end interface.
@@ -81,8 +81,8 @@ module iob_cache_axi
        )
    front_end
      (
-      .clk   (clk),
-      .reset (rst),
+      .clk   (clk_i),
+      .reset (rst_i),
 
       // front-end port
       .req (req),
@@ -146,8 +146,8 @@ module iob_cache_axi
        )
    cache_memory
      (
-      .clk   (clk),
-      .reset (rst),
+      .clk   (clk_i),
+      .reset (rst_i),
 
       // front-end
       .req (data_req),
@@ -219,8 +219,8 @@ module iob_cache_axi
 
       //back-end AXI4 interface
 `include "iob_cache_axi_portmap.vh"
-      .clk(clk),
-      .rst(rst)  
+      .clk_i(clk_i),
+      .rst_i(rst_i)  
       );
 
    //Cache control & Cache control block.
@@ -233,8 +233,8 @@ module iob_cache_axi
             )
       cache_control
         (
-         .clk   (clk),
-         .reset (rst),
+         .clk   (clk_i),
+         .reset (rst_i),
 
          // control's signals
          .valid (ctrl_req),

--- a/hardware/src/iob_cache_back_end.v
+++ b/hardware/src/iob_cache_back_end.v
@@ -12,7 +12,7 @@ module iob_cache_back_end
     parameter WRITE_POL = `IOB_CACHE_WRITE_THROUGH
     )
    (
-    input                                                              clk,
+    input                                                              clk_i,
     input                                                              reset,
 
     // write-through-buffer
@@ -55,7 +55,7 @@ module iob_cache_back_end
        )
    read_fsm
      (
-      .clk(clk),
+      .clk_i(clk_i),
       .reset(reset),
       .replace_valid (replace_valid),
       .replace_addr (replace_addr),
@@ -80,7 +80,7 @@ module iob_cache_back_end
        )
    write_fsm
      (
-      .clk(clk),
+      .clk_i(clk_i),
       .reset(reset),
       
       .valid (write_valid),

--- a/hardware/src/iob_cache_back_end_axi.v
+++ b/hardware/src/iob_cache_back_end_axi.v
@@ -60,7 +60,7 @@ module iob_cache_back_end_axi
       .read_addr (read_addr),
       .read_rdata (read_rdata),
       `include "iob_cache_m_axi_read_portmap.vh"
-      .clk(clk_i),
+      .clk_i(clk_i),
       .reset(rst_i)
       );
 
@@ -86,7 +86,7 @@ module iob_cache_back_end_axi
       .wdata (write_wdata),
       .ready (write_ready),
       `include "iob_cache_m_axi_write_portmap.vh"
-      .clk(clk_i),
+      .clk_i(clk_i),
       .reset(rst_i)
       );
 

--- a/hardware/src/iob_cache_back_end_axi.v
+++ b/hardware/src/iob_cache_back_end_axi.v
@@ -35,7 +35,7 @@ module iob_cache_back_end_axi
                                                                     
     // Back-end interface (AXI4 master)
 `include "iob_cache_axi_m_port.vh"
-`include "iob_gen_if.vh"
+`include "iob_clkrst_port.vh"
     );
 
    iob_cache_read_channel_axi
@@ -60,8 +60,8 @@ module iob_cache_back_end_axi
       .read_addr (read_addr),
       .read_rdata (read_rdata),
       `include "iob_cache_m_axi_read_portmap.vh"
-      .clk(clk),
-      .reset(rst)
+      .clk(clk_i),
+      .reset(rst_i)
       );
 
    iob_cache_write_channel_axi
@@ -86,8 +86,8 @@ module iob_cache_back_end_axi
       .wdata (write_wdata),
       .ready (write_ready),
       `include "iob_cache_m_axi_write_portmap.vh"
-      .clk(clk),
-      .reset(rst)
+      .clk(clk_i),
+      .reset(rst_i)
       );
 
 endmodule

--- a/hardware/src/iob_cache_control.v
+++ b/hardware/src/iob_cache_control.v
@@ -14,7 +14,7 @@ module iob_cache_control
     parameter USE_CTRL_CNT = 1
     )
    (
-    input                      clk,
+    input                      clk_i,
     input                      reset,
     input                      valid,
     input [`iob_cache_swreg_ADDR_W-1:0]   addr,
@@ -38,7 +38,7 @@ module iob_cache_control
          assign hit_cnt  = read_hit_cnt  + write_hit_cnt;
          assign miss_cnt = read_miss_cnt + write_miss_cnt;
 
-         always @(posedge clk, posedge reset) begin
+         always @(posedge clk_i, posedge reset) begin
             if (reset) begin
                read_hit_cnt   <= {DATA_W{1'b0}};
                read_miss_cnt  <= {DATA_W{1'b0}};
@@ -68,7 +68,7 @@ module iob_cache_control
             end
          end
 
-         always @(posedge clk) begin
+         always @(posedge clk_i) begin
             rdata <= {DATA_W{1'b0}};
             invalidate <= 1'b0;
             reset_counters <= 1'b0;
@@ -92,7 +92,7 @@ module iob_cache_control
          end
       end
       
-         always @(posedge clk) begin
+         always @(posedge clk_i) begin
             rdata <= {DATA_W{1'b0}};
             invalidate <= 1'b0;
             ready <= valid; // Sends acknowlege the next clock cycle after request (handshake)

--- a/hardware/src/iob_cache_front_end.v
+++ b/hardware/src/iob_cache_front_end.v
@@ -15,7 +15,7 @@ module iob_cache_front_end
     )
    (
     // front-end port
-    input                            clk,
+    input                            clk_i,
     input                            reset,
     input [USE_CTRL + ADDR_W -1:0] addr,
     input [DATA_W-1:0]               wdata,
@@ -68,7 +68,7 @@ module iob_cache_front_end
    endgenerate
 
    // register inputs
-   always @(posedge clk, posedge reset) begin
+   always @(posedge clk_i, posedge reset) begin
       if (reset) begin
          data_req_reg   <= 0;
          data_addr_reg  <= 0;

--- a/hardware/src/iob_cache_iob.v
+++ b/hardware/src/iob_cache_iob.v
@@ -44,7 +44,7 @@ module iob_cache_iob
     `IOB_OUTPUT(wtb_empty_out,1),
     
     //General Interface Signals
-    `include "iob_gen_if.vh"
+    `include "iob_clkrst_port.vh"
     );
 
    //BLOCK Front-end & This NIP interface is connected to a processor or any other processing element that needs a cache buffer to improve the performance of accessing a slower but larger memory.
@@ -75,8 +75,8 @@ module iob_cache_iob
        )
    front_end
      (
-      .clk(clk),
-      .reset(rst),
+      .clk(clk_i),
+      .reset(rst_i),
       
       // front-end port
       .req   (req),
@@ -139,8 +139,8 @@ module iob_cache_iob
        )
    cache_memory
      (
-      .clk   (clk),
-      .reset (rst),
+      .clk   (clk_i),
+      .reset (rst_i),
 
       // front-end
       .req       (data_req),
@@ -189,8 +189,8 @@ module iob_cache_iob
        )
    back_end
      (
-      .clk   (clk),
-      .reset (rst),
+      .clk   (clk_i),
+      .reset (rst_i),
 
       // write-through-buffer (write-channel)
       .write_valid (write_req),
@@ -226,8 +226,8 @@ module iob_cache_iob
             )
       cache_control
         (
-         .clk   (clk),
-         .reset (rst),
+         .clk   (clk_i),
+         .reset (rst_i),
 
          // control's signals
          .valid (ctrl_req),

--- a/hardware/src/iob_cache_iob.v
+++ b/hardware/src/iob_cache_iob.v
@@ -75,7 +75,7 @@ module iob_cache_iob
        )
    front_end
      (
-      .clk(clk_i),
+      .clk_i(clk_i),
       .reset(rst_i),
       
       // front-end port
@@ -139,7 +139,7 @@ module iob_cache_iob
        )
    cache_memory
      (
-      .clk   (clk_i),
+      .clk_i   (clk_i),
       .reset (rst_i),
 
       // front-end
@@ -189,7 +189,7 @@ module iob_cache_iob
        )
    back_end
      (
-      .clk   (clk_i),
+      .clk_i   (clk_i),
       .reset (rst_i),
 
       // write-through-buffer (write-channel)
@@ -226,7 +226,7 @@ module iob_cache_iob
             )
       cache_control
         (
-         .clk   (clk_i),
+         .clk_i   (clk_i),
          .reset (rst_i),
 
          // control's signals

--- a/hardware/src/iob_cache_read_channel.v
+++ b/hardware/src/iob_cache_read_channel.v
@@ -12,7 +12,7 @@ module iob_cache_read_channel
     parameter WORD_OFFSET_W = `IOB_CACHE_WORD_OFFSET_W
     )
    (
-    input                                    clk,
+    input                                    clk_i,
     input                                    reset,
     input                                    replace_valid,
     input [ADDR_W-1:`IOB_CACHE_BE_NBYTES_W+`IOB_CACHE_LINE2BE_W] replace_addr,
@@ -40,12 +40,12 @@ module iob_cache_read_channel
            handshake        = 2'd1, // the process was divided in 2 handshake steps to cause a delay in the
            end_handshake    = 2'd2; // (always 1 or a delayed valid signal), otherwise it will fail
 
-         always @(posedge clk)
+         always @(posedge clk_i)
            read_addr <= word_counter;
 
          reg [1:0]            state;
 
-         always @(posedge clk, posedge reset) begin
+         always @(posedge clk_i, posedge reset) begin
             if (reset) begin
                state <= idle;
             end else begin
@@ -104,7 +104,7 @@ module iob_cache_read_channel
 
          reg [1:0]                                  state;
 
-         always @(posedge clk, posedge reset) begin
+         always @(posedge clk_i, posedge reset) begin
             if (reset)
               state <= idle;
             else begin

--- a/hardware/src/iob_cache_read_channel_axi.v
+++ b/hardware/src/iob_cache_read_channel_axi.v
@@ -23,7 +23,7 @@ module iob_cache_read_channel_axi
     output reg [`IOB_CACHE_LINE2BE_W-1:0]              read_addr,
     output [BE_DATA_W-1:0]                   read_rdata,
 `include "iob_cache_m_axi_m_read_port.vh"
-    input                                    clk,
+    input                                    clk_i,
     input                                    reset
     );
 
@@ -62,7 +62,7 @@ module iob_cache_read_channel_axi
          reg [1:0]                           state;
          reg                                 slave_error; // axi slave_error during reply (axi_rresp[1] == 1) - burst can't be interrupted, so a flag needs to be active
 
-         always @(posedge clk, posedge reset) begin
+         always @(posedge clk_i, posedge reset) begin
             if (reset) begin
                state <= idle;
                read_addr <= 0;
@@ -154,7 +154,7 @@ module iob_cache_read_channel_axi
 
          reg [1:0]                           state;
 
-         always @(posedge clk, posedge reset) begin
+         always @(posedge clk_i, posedge reset) begin
             if (reset)
               state <= idle;
             else

--- a/hardware/src/iob_cache_replacement_policy.v
+++ b/hardware/src/iob_cache_replacement_policy.v
@@ -1,5 +1,6 @@
 `timescale 1ns / 1ps
 
+`include "iob_cache_conf.vh"
 `include "iob_cache.vh"
 
 module iob_cache_replacement_policy

--- a/hardware/src/iob_cache_replacement_policy.v
+++ b/hardware/src/iob_cache_replacement_policy.v
@@ -11,7 +11,7 @@ module iob_cache_replacement_policy
     parameter REP_POLICY = `IOB_CACHE_PLRU_TREE
     )
    (
-    input                clk,
+    input                clk_i,
     input                reset,
     input                write_en,
     input [N_WAYS-1:0]   way_hit,
@@ -58,7 +58,7 @@ module iob_cache_replacement_policy
              )
          mru_memory // simply uses the same format as valid memory
            (
-            .clk    (clk      ),
+            .clk    (clk_i      ),
             .rst    (reset    ),
 
             .we     (write_en ),
@@ -94,7 +94,7 @@ module iob_cache_replacement_policy
              )
          mru_memory // simply uses the same format as valid memory
            (
-            .clk    (clk      ),
+            .clk    (clk_i      ),
             .rst    (reset    ),
 
             .we     (write_en ),
@@ -163,7 +163,7 @@ module iob_cache_replacement_policy
                )
            mru_memory // simply uses the same format as valid memory
              (
-              .clk    (clk      ),
+              .clk    (clk_i      ),
               .rst    (reset    ),
 
               .we     (write_en ),

--- a/hardware/src/iob_cache_write_channel.v
+++ b/hardware/src/iob_cache_write_channel.v
@@ -13,7 +13,7 @@ module iob_cache_write_channel
     parameter WORD_OFFSET_W = `IOB_CACHE_WORD_OFFSET_W
     )
    (
-    input                                                                      clk,
+    input                                                                      clk_i,
     input                                                                      reset,
 
     input                                                                      valid,
@@ -69,7 +69,7 @@ module iob_cache_write_channel
             end
          end
 
-         always @(posedge clk, posedge reset) begin
+         always @(posedge clk_i, posedge reset) begin
             if (reset)
               state <= idle;
             else
@@ -108,7 +108,7 @@ module iob_cache_write_channel
       end else begin // if (WRITE_POL == WRITE_BACK)
          if (`IOB_CACHE_LINE2BE_W > 0) begin
             reg [`IOB_CACHE_LINE2BE_W-1:0] word_counter, word_counter_reg;
-            always @(posedge clk)
+            always @(posedge clk_i)
               word_counter_reg <= word_counter;
 
             // memory address
@@ -123,7 +123,7 @@ module iob_cache_write_channel
 
             reg [0:0]            state;
 
-            always @(posedge clk, posedge reset) begin
+            always @(posedge clk_i, posedge reset) begin
                if (reset)
                  state <= idle;
                else
@@ -176,7 +176,7 @@ module iob_cache_write_channel
 
             reg [0:0]            state;
 
-            always @(posedge clk, posedge reset) begin
+            always @(posedge clk_i, posedge reset) begin
                if (reset)
                  state <= idle;
                else

--- a/hardware/src/iob_cache_write_channel_axi.v
+++ b/hardware/src/iob_cache_write_channel_axi.v
@@ -24,7 +24,7 @@ module iob_cache_write_channel_axi
     input [`IOB_CACHE_NBYTES-1:0]                                                wstrb,
     output reg                                                         ready,
 `include "iob_cache_m_axi_m_write_port.vh"
-    input                                                              clk,
+    input                                                              clk_i,
     input                                                              reset 
     );
 
@@ -74,7 +74,7 @@ module iob_cache_write_channel_axi
 
          reg [1:0]                               state;
 
-         always @(posedge clk, posedge reset) begin
+         always @(posedge clk_i, posedge reset) begin
             if (reset)
               state <= idle;
             else
@@ -162,7 +162,7 @@ module iob_cache_write_channel_axi
 
             reg [1:0]            state;
 
-            always @(posedge clk, posedge reset) begin
+            always @(posedge clk_i, posedge reset) begin
                if (reset) begin
                   state <= idle;
                   word_counter <= 0;
@@ -252,7 +252,7 @@ module iob_cache_write_channel_axi
 
             reg [1:0]                           state;
 
-            always @(posedge clk, posedge reset) begin
+            always @(posedge clk_i, posedge reset) begin
                if (reset)
                  state <= idle;
                else

--- a/hardware/src/iob_cache_write_channel_axi.v
+++ b/hardware/src/iob_cache_write_channel_axi.v
@@ -1,5 +1,6 @@
 `timescale 1ns / 1ps
 
+`include "iob_cache_conf.vh"
 `include "iob_cache.vh"
 
 module iob_cache_write_channel_axi


### PR DESCRIPTION
- update LIB submodule
- refactor cache hardware sources to use `clk_i` and `rst_i` as generic port names
- add missing `iob_cache_conf.vh` includes