### PR TITLE
BREAKING(build-lib): modified _setup.mk to match iob-uart; add iob_cache_setup.py file

### DIFF
--- a/hardware/hw_setup.mk
+++ b/hardware/hw_setup.mk
@@ -1,11 +1,14 @@
 # (c) 2022-Present IObundle, Lda, all rights reserved
 #
-# This makefile segment is used at setup-time in $(LIB_DIR)/Makefile
+# This makefile segment lists all hardware header and source files 
 #
-# It copies all hardware header and source files to $(BUILD_DIR)/hw
+# It is always included in submodules/LIB/Makefile for populating the
+# build directory
 #
-#
+ifeq ($(filter CACHE, $(HW_MODULES)),)
 
+#add itself to HW_MODULES list
+HW_MODULES+=CACHE
 
 #import lib hardware
 include $(LIB_DIR)/hardware/include/hw_setup.mk
@@ -14,50 +17,4 @@ include $(LIB_DIR)/hardware/fifo/iob_fifo_sync/hw_setup.mk
 include $(LIB_DIR)/hardware/ram/iob_ram_2p/hw_setup.mk
 include $(LIB_DIR)/hardware/ram/iob_ram_sp/hw_setup.mk
 
-# copy verilog sources
-SRC+=$(patsubst $(CACHE_DIR)/hardware/src/%, $(BUILD_VSRC_DIR)/%, $(wildcard $(CACHE_DIR)/hardware/src/*))
-$(BUILD_VSRC_DIR)/%: $(CACHE_DIR)/hardware/src/%
-	cp $< $@
-
-#select core configuration
-SRC+=$(BUILD_VSRC_DIR)/iob_cache_conf.vh
-$(BUILD_VSRC_DIR)/iob_cache_conf.vh: $(CACHE_DIR)/hardware/src/iob_cache_conf_$(CACHE_CONFIG).vh
-	cp $< $@
-
-#generate axi headers
-AXI_GEN:= $(LIB_DIR)/scripts/if_gen.py
-
-# generate axi ports
-SRC+=$(BUILD_VSRC_DIR)/iob_cache_axi_m_port.vh
-$(BUILD_VSRC_DIR)/iob_cache_axi_m_port.vh:
-	$(AXI_GEN) axi_m_port iob_cache_ --top && cp iob_cache_axi_m_port.vh $(BUILD_VSRC_DIR)
-
-# generate portmap for axi instance
-SRC+=$(BUILD_VSRC_DIR)/iob_cache_axi_m_m_portmap.vh
-$(BUILD_VSRC_DIR)/iob_cache_axi_m_m_portmap.vh:
-	$(AXI_GEN) axi_m_m_portmap iob_cache_ && cp iob_cache_axi_m_m_portmap.vh $(BUILD_VSRC_DIR)
-
-# generate axi write port for axi write module
-SRC+=$(BUILD_VSRC_DIR)/iob_cache_axi_m_write_port.vh
-$(BUILD_VSRC_DIR)/iob_cache_axi_m_write_port.vh:
-	$(AXI_GEN) axi_m_write_port iob_cache_ && cp iob_cache_axi_m_write_port.vh $(BUILD_VSRC_DIR)
-
-# generate axi write portmap for axi write instance
-SRC+=$(BUILD_VSRC_DIR)/iob_cache_axi_m_m_write_portmap.vh
-$(BUILD_VSRC_DIR)/iob_cache_axi_m_m_write_portmap.vh:
-	$(AXI_GEN) axi_m_m_write_portmap iob_cache_ && cp iob_cache_axi_m_m_write_portmap.vh $(BUILD_VSRC_DIR)
-
-# generate axi write port for axi read module
-SRC+=$(BUILD_VSRC_DIR)/iob_cache_axi_m_read_port.vh
-$(BUILD_VSRC_DIR)/iob_cache_axi_m_read_port.vh:
-	$(AXI_GEN) axi_m_read_port iob_cache_ && cp iob_cache_axi_m_read_port.vh $(BUILD_VSRC_DIR)
-
-# generate axi write portmap for axi read module
-SRC+=$(BUILD_VSRC_DIR)/iob_cache_axi_m_m_read_portmap.vh
-$(BUILD_VSRC_DIR)/iob_cache_axi_m_m_read_portmap.vh:
-	$(AXI_GEN) axi_m_m_read_portmap iob_cache_ && cp iob_cache_axi_m_m_read_portmap.vh $(BUILD_VSRC_DIR)
-
-# turn iob_cache_swreg_gen.v into an unused header as this core does not use it
-SRC+=$(BUILD_VSRC_DIR)/iob_cache_swreg_gen.vh
-$(BUILD_VSRC_DIR)/iob_cache_swreg_gen.vh: $(BUILD_VSRC_DIR)/iob_cache_swreg_gen.v
-	mv $(BUILD_VSRC_DIR)/iob_cache_swreg_gen.v $(BUILD_VSRC_DIR)/iob_cache_swreg_gen.vh
+endif

--- a/iob_cache_setup.py
+++ b/iob_cache_setup.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+
+import os, sys
+sys.path.insert(0, os.getcwd()+'/submodules/LIB/scripts')
+from setup import setup
+
+top = 'iob_cache'
+version = 'V0.10'
+
+confs = \
+[
+    #TODO: Need to handle ifdef AXI
+    #{'name':'AXI_ID_W', 'type':'P', 'val':'`IOB_CACHE_AXI_ID_W', 'min':'1', 'max':'NA', 'descr':'AXI ID bus width'},
+    #{'name':'AXI_LEN_W', 'type':'P', 'val':'`IOB_CACHE_AXI_LEN_W', 'min':'1', 'max':'NA', 'descr':'AXI LEN bus width'},
+    #{'name':'AXI_ADDR_W', 'type':'P', 'val':'BE_ADDR_W', 'min':'1', 'max':'NA', 'descr':'AXI address bus width'},
+    #{'name':'AXI_DATA_W', 'type':'P', 'val':'BE_DATA_W', 'min':'1', 'max':'NA', 'descr':'AXI data bus width'},
+    #{'name':'[AXI_ID_W-1:0] AXI_ID', 'type':'P', 'val':'`IOB_CACHE_AXI_ID', 'min':'?', 'max':'NA', 'descr':'AXI ID bus'},
+
+    {'name':'ADDR_W', 'type':'P', 'val':'`IOB_CACHE_ADDR_W', 'min':'1', 'max':'64', 'descr':'Front-end address width (log2): defines the total memory space accessible via the cache, which must be a power of two.'},
+    {'name':'DATA_W', 'type':'P', 'val':'`IOB_CACHE_DATA_W', 'min':'32', 'max':'64', 'descr':'Front-end data width (log2): this parameter allows supporting processing elements with various data widths.'},
+    {'name':'BE_ADDR_W', 'type':'P', 'val':'`IOB_CACHE_BE_ADDR_W', 'min':'1', 'max':'', 'descr':'Back-end address width (log2): the value of this parameter must be equal or greater than ADDR_W to match the width of the back-end interface, but the address space is still dictated by ADDR_W.'},
+    {'name':'BE_DATA_W', 'type':'P', 'val':'`IOB_CACHE_BE_DATA_W', 'min':'32', 'max':'256', 'descr':'Back-end data width (log2): the value of this parameter must be an integer  multiple $k \geq 1$ of DATA_W. If $k>1$, the memory controller can operate at a frequency higher than the cache\'s frequency. Typically, the memory controller has an asynchronous FIFO interface, so that it can sequentially process multiple commands received in paralell from the cache\'s back-end interface. '},
+    {'name':'NWAYS_W', 'type':'P', 'val':'`IOB_CACHE_NWAYS_W', 'min':'0', 'max':'8', 'descr':'Number of cache ways (log2): the miminum is 0 for a directly mapped cache; the default is 1 for a two-way cache; the maximum is limited by the desired maximum operating frequency, which degrades with the number of ways. '},
+    {'name':'NLINES_W', 'type':'P', 'val':'`IOB_CACHE_NLINES_W', 'min':'', 'max':'', 'descr':'Line offset width (log2): the value of this parameter equals the number of cache lines, given by 2**NLINES_W.'},
+    {'name':'WORD_OFFSET_W', 'type':'P', 'val':'`IOB_CACHE_WORD_OFFSET_W', 'min':'0', 'max':'', 'descr':'Word offset width (log2):  the value of this parameter equals the number of words per line, which is 2**OFFSET_W. '},
+    {'name':'WTBUF_DEPTH_W', 'type':'P', 'val':'`IOB_CACHE_WTBUF_DEPTH_W', 'min':'', 'max':'', 'descr':'Write-through buffer depth (log2). A shallow buffer will fill up more frequently and cause write stalls; however, on a Read After Write (RAW) event, a shallow buffer will empty faster, decreasing the duration of the read stall. A deep buffer is unlkely to get full and cause write stalls; on the other hand, on a RAW event, it will take a long time to empty and cause long read stalls.'},
+    {'name':'REP_POLICY', 'type':'P', 'val':'`IOB_CACHE_REP_POLICY', 'min':'0', 'max':'3', 'descr':'Line replacement policy: set to 0 for Least Recently Used (LRU); set to 1 for Pseudo LRU based on Most Recently Used (PLRU_MRU); set to 2 for tree-based Pseudo LRU (PLRU_TREE).'},
+    {'name':'WRITE_POL', 'type':'P', 'val':'`IOB_CACHE_WRITE_THROUGH', 'min':'0', 'max':'1', 'descr':'Write policy: set to 0 for write-through or set to 1 for write-back.'},
+    {'name':'USE_CTRL', 'type':'P', 'val':'`IOB_CACHE_USE_CTRL', 'min':'0', 'max':'1', 'descr':'Instantiates a cache controller (1) or not (0). The cache controller provides memory-mapped software accessible registers to invalidate the cache data contents, and monitor the write through buffer status using the front-end interface. To access the cache controller, the MSB of the address mut be set to 1. For more information refer to the example software functions provided.'},
+    {'name':'USE_CTRL_CNT', 'type':'P', 'val':'`IOB_CACHE_USE_CTRL_CNT', 'min':'0', 'max':'1', 'descr':'Instantiates hit/miss counters for reads, writes or both (1), or not (0). This parameter is meaningful if the cache controller is present (USE_CTRL=1), providing additional software accessible functions for these functions.'}
+]
+
+ios = \
+[
+    {'name': 'fe', 'descr':'Front-end interface (IOb native slave)', 'ports': [
+        {'name':'req', 'type':'I', 'n_bits':'1', 'descr':'Read or write request from host. If signal {\tt ack} raises in the next cyle the request has been served; otherwise {\tt req} should remain high until {\tt ack} raises. When {\tt ack} raises in response to a previous request, {\tt req} may keep high, or combinatorially lowered in the same cycle. If {\tt req} keeps high, a new request is being made to the current address {\tt addr}; if {\tt req} lowers, no new request is being made. Note that the new request is being made in parallel with acknowledging the previous request: pipelined operation.'},
+        {'name':'addr', 'type':'I', 'n_bits':'USE_CTRL+ADDR_W-`IOB_CACHE_NBYTES_W', 'descr':'Address from CPU or other user core, excluding the byte selection LSBs.'},
+        {'name':'wdata', 'type':'I', 'n_bits':'DATA_W', 'descr':'Write data fom host.'},
+        {'name':'wstrb', 'type':'I', 'n_bits':'`IOB_CACHE_NBYTES', 'descr':'Byte write strobe from host.'},
+        {'name':'rdata', 'type':'O', 'n_bits':'DATA_W', 'descr':'Read data to host.'},
+        {'name':'ack', 'type':'O','n_bits':'1', 'descr':'Acknowledge signal from cache: indicates that the last request has been served. The next request can be issued as soon as this signal raises, in the same clock cycle, or later after it becomes low.'}
+    ]},
+    {'name': 'be', 'descr':'Back-end interface', 'ports': [
+#`ifdef AXI #TODO: Need to handle ifdef AXI
+         #`include "iob_cache_axi_m_port.vh"
+#`else
+        {'name':'', 'type':'O', 'n_bits':'1', 'descr':'Read or write request to next-level cache or memory.'},
+        {'name':'be_addr', 'type':'O', 'n_bits':'BE_ADDR_W', 'descr':'Address to next-level cache or memory.'},
+        {'name':'be_wdata', 'type':'O', 'n_bits':'BE_DATA_W', 'descr':'Write data to next-level cache or memory.'},
+        {'name':'be_wstrb', 'type':'O', 'n_bits':'`IOB_CACHE_BE_NBYTES', 'descr':'Write strobe to next-level cache or memory.'},
+        {'name':'be_rdata', 'type':'I', 'n_bits':'BE_DATA_W', 'descr':'Read data from next-level cache or memory.'},
+        {'name':'be_ack', 'type':'I', 'n_bits':'1', 'descr':'Acknowledge signal from next-level cache or memory.'}
+#`endif
+    ]},
+    {'name': 'ie', 'descr':'Cache invalidate and write-trough buffer IO chain', 'ports': [
+        {'name':'invalidate_in', 'type':'I','n_bits':'1', 'descr':'Invalidates all cache lines instantaneously if high.'},
+        {'name':'invalidate_out', 'type':'O','n_bits':'1', 'descr':'This output is asserted high when the cache is invalidated via the cache controller or the direct {\tt invalidate_in} signal. The present {\tt invalidate_out} signal is useful for invalidating the next-level cache if there is one. If not, this output should be floated.'},
+        {'name':'wtb_empty_in', 'type':'I','n_bits':'1', 'descr':'This input is driven by the next-level cache, if there is one, when its write-through buffer is empty. It should be tied high if there is no next-level cache. This signal is used to compute the overall empty status of a cache hierarchy, as explained for signal {\tt wtb_empty_out}.'},
+        {'name':'wtb_empty_out', 'type':'O','n_bits':'1', 'descr':'This output is high if the cache\'s write-through buffer is empty and its {\tt wtb_empty_in} signal is high. This signal informs that all data written to the cache has been written to the destination memory module, and all caches on the way are empty.'},
+    ]},
+    {'name': 'ge', 'descr':'General Interface Signals', 'ports': [
+        {'name':'clk_i', 'type':'I', 'n_bits':'1', 'descr':'System clock input.'},
+        {'name':'arst_i', 'type':'I', 'n_bits':'1', 'descr':'System reset, asynchronous and active high.'}
+    ]}
+]
+
+regs = \
+[
+    {'name': 'cache', 'descr':'CACHE software accessible registers.', 'regs': [
+        {'name':'WTB_EMPTY', 'type':"R", 'n_bits':'1', 'rst_val':'0', 'addr':'0', 'n_items':'1', 'autologic':False, 'descr':"Write-through buffer empty (1) or non-empty (0)."} 
+        {'name':'WTB_FULL', 'type':"R", 'n_bits':'1', 'rst_val':'0', 'addr':'1', 'n_items':'1', 'autologic':False, 'descr':"Write-through buffer full (1) or non-full (0)."},
+        {'name':'RW_HIT', 'type':"R", 'n_bits':'32', 'rst_val':'0', 'addr':'4', 'n_items':'1', 'autologic':False, 'descr':"Read and write hit counter."},
+        {'name':'RW_MISS', 'type':"R", 'n_bits':'32', 'rst_val':'0', 'addr':'8', 'n_items':'1', 'autologic':False, 'descr':"Read and write miss counter."},
+        {'name':'READ_HIT', 'type':"R", 'n_bits':'32', 'rst_val':'0', 'addr':'12', 'n_items':'1', 'autologic':False, 'descr':"Read hit counter."},
+        {'name':'READ_MISS', 'type':"R", 'n_bits':'32', 'rst_val':'0', 'addr':'16', 'n_items':'1', 'autologic':False, 'descr':"Read miss counter."},
+        {'name':'WRITE_HIT', 'type':"R", 'n_bits':'32', 'rst_val':'0', 'addr':'20', 'n_items':'1', 'autologic':False, 'descr':"Write hit counter."},
+        {'name':'WRITE_MISS', 'type':"R", 'n_bits':'32', 'rst_val':'0', 'addr':'24', 'n_items':'1', 'autologic':False, 'descr':"Write miss counter."},
+        {'name':'RST_CNTRS', 'type':"W", 'n_bits':'1', 'rst_val':'0', 'addr':'28', 'n_items':'1', 'autologic':False, 'descr':"Reset read/write hit/miss counters by writing any value to this register."},
+        {'name':'INVALIDATE', 'type':"W", 'n_bits':'1', 'rst_val':'0', 'addr':'32', 'n_items':'1', 'autologic':False, 'descr':"Invalidate the cache data contents by writing any value to this register."},
+        {'name':'VERSION', 'type':"R", 'n_bits':'32', 'rst_val':'0', 'addr':'36', 'n_items':'1', 'autologic':False, 'descr':"Cache version."}
+    ]}
+]
+
+blocks = []
+
+if __name__ == "__main__":
+    setup(top, version, confs, ios, regs, blocks)

--- a/software/sw_setup.mk
+++ b/software/sw_setup.mk
@@ -1,23 +1,15 @@
 # (c) 2022-Present IObundle, Lda, all rights reserved
 #
-# This makefile segment  is used at setup-time in $(LIB_DIR)/Makefile
+# This makefile segment lists all software header and source files 
 #
-# It copies all software header and source files to $(BUILD_DIR)/sw
+# It is included in submodules/LIB/Makefile for populating the
+# build directory
 #
 
-# sw accessible registers C header and source files
-# pc-emul sources
-SRC+=$(BUILD_PSRC_DIR)/iob_cache_swreg.h
+ifeq ($(filter CACHE, $(SW_MODULES)),)
 
-$(BUILD_PSRC_DIR)/iob_cache_swreg.h: iob_cache_swreg.h
-	cp $< $@
+#add itself to SW_MODULES list
+SW_MODULES+=CACHE
 
-# embedded sources
-SRC+=$(BUILD_ESRC_DIR)/iob_cache_swreg.h $(BUILD_ESRC_DIR)/iob_cache_swreg_emb.c
 
-$(BUILD_ESRC_DIR)/iob_cache_swreg%: iob_cache_swreg%
-	mv $< $@
-
-iob_cache_swreg.h iob_cache_swreg_emb.c: $(CACHE_DIR)/mkregs.toml
-	$(LIB_DIR)/scripts/mkregs.py iob_cache $(CACHE_DIR) SW
-
+endif


### PR DESCRIPTION
- Add iob_cache_setup.py file
- Do not call setup() function if module is imported by another.
- BREAKING: modified _setup.mk to match iob-uart
  - Modified hw_setup.mk and sw_setup.mk file to match ones from iob-uart.
    - This may break the build process for this component
    - I need to investigate more about the iob-uart build process to
      ensure it also works for the cache.
    - These changes allow for iob-soc/build-lib to create the build directory,
      but it currently does not run in simulation.
- Update LIB