### PR TITLE
feat(setup): Use new setup process: Call `iob_cache.py` directly.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,26 @@
 CORE := iob_cache
 DISABLE_LINT:=1
-include submodules/LIB/setup.mk
-
 BE_IF ?= "AXI4"
 SETUP_ARGS += BE_IF=$(BE_IF)
 BE_DATA_W ?= "32"
 SETUP_ARGS += BE_DATA_W=$(BE_DATA_W)
 
-sim-build: clean
+clean:
 	rm -rf ../$(CORE)_V*
-	make setup BE_IF=$(BE_IF) BE_DATA_W=$(BE_DATA_W) && make -C ../$(CORE)_V*/ sim-build
 
-sim-run: clean
-	rm -rf ../$(CORE)_V*
-	make setup BE_IF=$(BE_IF) BE_DATA_W=$(BE_DATA_W)  && make -C ../$(CORE)_V*/ sim-run
+setup:
+	python3 -B ./$(CORE).py BE_IF=$(BE_IF) BE_DATA_W=$(BE_DATA_W)
+
+sim-build: clean setup
+	make -C ../$(CORE)_V*/ sim-build
+
+sim-run: clean setup
+	make -C ../$(CORE)_V*/ sim-run
 
 sim-waves:
 	make -C ../$(CORE)_V*/ sim-waves
 
-sim-test: clean
-	rm -rf ../$(CORE)_V*
-	make setup BE_IF=$(BE_IF) BE_DATA_W=$(BE_DATA_W) && make -C ../$(CORE)_V*/ sim-test
+sim-test: clean setup
+	make -C ../$(CORE)_V*/ sim-test
 
 

--- a/iob_cache.py
+++ b/iob_cache.py
@@ -3,7 +3,12 @@
 import os
 import sys
 
+# Find python modules
+if __name__ == "__main__":
+    sys.path.append("./submodules/LIB/scripts")
 from iob_module import iob_module
+if __name__ == "__main__":
+    iob_module.find_modules()
 
 # Submodules
 from iob_utils import iob_utils
@@ -573,3 +578,7 @@ class iob_cache(iob_module):
     @classmethod
     def _setup_block_groups(cls):
         cls.block_groups += []
+
+
+if __name__ == "__main__":
+    iob_cache.setup_as_top_module()


### PR DESCRIPTION
New setup process no longer uses setup.mk or bootstrap.py The user calls `python3 -B ./iob_cache.py` directly to intiate the setup process (create the build dir).
Checkout the contents of the Makefile for examples.