### PR TITLE
fix(sw): remove redundant functions

### DIFF
--- a/software/src/iob-cache.c
+++ b/software/src/iob-cache.c
@@ -6,28 +6,5 @@ static int cache_base;
 
 void cache_init(int ext_mem, int cache_addr) {
   cache_base = ext_mem + (1 << (cache_addr));
+  IOB_CACHE_INIT_BASEADDR(cache_base);
 }
-
-int cache_invalidate() { return (CACHEFUNC(cache_base, IOB_CACHE_INVALIDATE)); }
-
-int cache_wtb_empty() { return (CACHEFUNC(cache_base, IOB_CACHE_WTB_EMPTY)); }
-
-int cache_wtb_full() { return (CACHEFUNC(cache_base, IOB_CACHE_WTB_FULL)); }
-
-int cache_hit() { return (CACHEFUNC(cache_base, IOB_CACHE_RW_HIT)); }
-
-int cache_miss() { return (CACHEFUNC(cache_base, IOB_CACHE_RW_MISS)); }
-
-int cache_read_hit() { return (CACHEFUNC(cache_base, IOB_CACHE_READ_HIT)); }
-
-int cache_read_miss() { return (CACHEFUNC(cache_base, IOB_CACHE_READ_MISS)); }
-
-int cache_write_hit() { return (CACHEFUNC(cache_base, IOB_CACHE_WRITE_HIT)); }
-
-int cache_write_miss() { return (CACHEFUNC(cache_base, IOB_CACHE_WRITE_MISS)); }
-
-int cache_counter_reset() {
-  return (CACHEFUNC(cache_base, IOB_CACHE_RST_CNTRS));
-}
-
-int cache_version() { return (CACHEFUNC(cache_base, IOB_CACHE_VERSION)); }

--- a/software/src/iob-cache.h
+++ b/software/src/iob-cache.h
@@ -3,20 +3,6 @@
 
 #include "iob_cache_swreg.h"
 
-#define CACHEFUNC(cache_base, func)                                            \
-  (*((volatile int *)(cache_base + (func * sizeof(int)))))
-
 // Cache Controllers's functions
 void cache_init(int ext_mem,
-                int cache_addr); // initialized the cache_base static integer
-int cache_invalidate();
-int cache_wtb_empty();
-int cache_wtb_full();
-int cache_hit();
-int cache_miss();
-int cache_read_hit();
-int cache_read_miss();
-int cache_write_hit();
-int cache_write_miss();
-int cache_counter_reset();
-int cache_version();
+                int cache_addr); // initialize the cache_base static integer


### PR DESCRIPTION
- remove redundant software functions. These functions are already generated in iob_cache_swreg_emb.c