### PR TITLE
Some bugs is fixed

### DIFF
--- a/hardware/src/iob_cache_write_channel_axi.v
+++ b/hardware/src/iob_cache_write_channel_axi.v
@@ -152,8 +152,6 @@ module iob_cache_write_channel_axi #(
                   state        <= idle;
                   word_counter <= 0;
                end else begin
-                  word_counter <= 0;
-
                   case (state)
                      idle:
                      if (valid_i) state <= address;
@@ -162,9 +160,10 @@ module iob_cache_write_channel_axi #(
                      if (axi_awready_i) state <= write;
                      else state <= address;
                      write:
-                     if (axi_wready_i & (&word_counter))  // last word written
+                     if (axi_wready_i & (&word_counter))  begin // last word written
                         state <= verif;
-                     else if (axi_wready_i & ~(&word_counter)) begin  // word still available
+                        word_counter <= 0;
+                     end else if (axi_wready_i & ~(&word_counter)) begin  // word still available
                         state        <= write;
                         word_counter <= word_counter + 1;
                      end else begin  // waiting for handshake


### PR DESCRIPTION
Firstly, this is a great project!
I integrate IOB-Cache in my design, through simulation and find several bugs.
1. index is not a vector based on way and in write-back, it will cause malfuction.
2. in one-way cache, the write_req_o should also occur when read miss and old cache line be flushed to memory
3.  This line - assign write_req_o = req_reg_i & ~(|way_hit) & (way_select == dirty); //flush if there is not a hit, and the way selected is dirty
   way_select is one-hot but dirty is not , how can compare it? please check if my modification is right.
  assign write_req_o = req_reg_i & ~(|way_hit) & dirty[way_select_bin];