### PR TITLE
feat(AXI): Remove AXI submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "submodules/AXI"]
-	path = submodules/AXI
-	url = git@github.com:IObundle/verilog-axi.git


### PR DESCRIPTION
Remove AXI submodule because IOb-SoC already has it, and cache tests only work with IOb-SoC either way.
This cache AXI submodule also causes issues with github actions, by leaving untracked changes on multiple runs.